### PR TITLE
feat(footer): auto detect hosting platform

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,5 +6,12 @@
   "editor.quickSuggestions": {
     "strings": true
   },
-  "tailwindCSS.classAttributes": ["class", "className", "ngClass", "ui"]
+  "tailwindCSS.classAttributes": [
+    "class",
+    "className",
+    "ngClass",
+    "ui",
+    "active-class",
+    "inactive-class"
+  ]
 }

--- a/components/FooterComp.vue
+++ b/components/FooterComp.vue
@@ -9,10 +9,58 @@
         },
       }"
     >
-      <div class="inline-flex items-center justify-between w-full dark:text-gray-400 text-gray-600 text-sm">
-        <span>© 2024 <a href="https://yfi.moe">Yunfi</a><br>Powered by Nuxt & Nuxt UI. Hosted on Vercel.</span>
-        <span>Source at <a href="https://github.com/yy4382/s3-image-port">GitHub</a></span>
+      <div
+        class="inline-flex items-center justify-between w-full dark:text-gray-400 text-gray-600 text-sm"
+      >
+        <span>
+          Copyright © 2024
+          <ULink
+            to="https://yfi.moe"
+            inactive-class="text-primary hover:underline"
+            >Yunfi</ULink
+          >
+          <br />
+          Powered by
+          <ULink
+            to="https://nuxt.com/"
+            inactive-class="text-primary hover:underline"
+            >Nuxt</ULink
+          >
+          &
+          <ULink
+            to="https://ui.nuxt.com/"
+            inactive-class="text-primary hover:underline"
+            >Nuxt UI</ULink
+          >.
+          {{ showHostingProvider ? `Hosted on ${hostingProvider}` : "" }}
+        </span>
+        <span
+          >Source at
+          <ULink
+            to="https://github.com/yy4382/s3-image-port"
+            inactive-class="text-primary hover:underline"
+            >GitHub</ULink
+          ></span
+        >
       </div>
     </UCard>
   </UContainer>
 </template>
+
+<script setup lang="ts">
+const showHostingProvider = ref(false);
+const hostingProvider = ref("");
+
+if (process.env.NETLIFY) {
+  console.log("Running on Netlify");
+  hostingProvider.value = "Netlify";
+  showHostingProvider.value = true;
+} else if (process.env.VERCEL) {
+  console.log("Running on Vercel");
+  hostingProvider.value = "Vercel";
+  showHostingProvider.value = true;
+} else {
+  console.log("Running on unknown hosting provider");
+  showHostingProvider.value = false;
+}
+</script>

--- a/components/FooterComp.vue
+++ b/components/FooterComp.vue
@@ -16,20 +16,20 @@
           Copyright © 2024
           <ULink
             to="https://yfi.moe"
-            inactive-class="text-primary hover:underline"
+            inactive-class="text-primary-500 dark:text-primary-400 hover:text-primary-600 dark:hover:text-primary-500 hover:underline hover:underline-offset-2 transition-colors"
             >Yunfi</ULink
           >
           <br />
           Powered by
           <ULink
             to="https://nuxt.com/"
-            inactive-class="text-primary hover:underline"
+            inactive-class="text-primary-500 dark:text-primary-400 hover:text-primary-600 dark:hover:text-primary-500 hover:underline hover:underline-offset-2 transition-colors"
             >Nuxt</ULink
           >
           &
           <ULink
             to="https://ui.nuxt.com/"
-            inactive-class="text-primary hover:underline"
+            inactive-class="text-primary-500 dark:text-primary-400 hover:text-primary-600 dark:hover:text-primary-500 hover:underline hover:underline-offset-2 transition-colors"
             >Nuxt UI</ULink
           >.
           {{ showHostingProvider ? `Hosted on ${hostingProvider}` : "" }}

--- a/components/FooterComp.vue
+++ b/components/FooterComp.vue
@@ -32,7 +32,7 @@
             inactive-class="text-primary-500 dark:text-primary-400 hover:text-primary-600 dark:hover:text-primary-500 hover:underline hover:underline-offset-2 transition-colors"
             >Nuxt UI</ULink
           >.
-          {{ showHostingProvider ? `Hosted on ${hostingProvider}` : "" }}
+          {{ hostingProvider ? `Hosted on ${hostingProvider}.` : "" }}
         </span>
         <span
           >Source at
@@ -48,19 +48,19 @@
 </template>
 
 <script setup lang="ts">
-const showHostingProvider = ref(false);
-const hostingProvider = ref("");
-
-if (process.env.NETLIFY) {
-  console.log("Running on Netlify");
-  hostingProvider.value = "Netlify";
-  showHostingProvider.value = true;
-} else if (process.env.VERCEL) {
-  console.log("Running on Vercel");
-  hostingProvider.value = "Vercel";
-  showHostingProvider.value = true;
-} else {
-  console.log("Running on unknown hosting provider");
-  showHostingProvider.value = false;
-}
+const { data: hostingProvider } = await useAsyncData(
+  "hostingProvider",
+  async () => {
+    if (process.env.NETLIFY) {
+      console.log("Running on Netlify");
+      return "Netlify";
+    } else if (process.env.VERCEL) {
+      console.log("Running on Vercel");
+      return "Vercel";
+    } else {
+      console.log("Running on unknown hosting provider");
+      return undefined;
+    }
+  }
+);
 </script>


### PR DESCRIPTION
Information about the hosting provider is now automatically detected and displayed in the footer. currently only `Vercel` and `Netlify` are supported to be detected, and will not be displayed if they are not one of those providers.