### PR TITLE
style: fix a missing dot in the footer text

### DIFF
--- a/components/FooterComp.vue
+++ b/components/FooterComp.vue
@@ -18,7 +18,7 @@
             to="https://yfi.moe"
             inactive-class="text-primary-500 dark:text-primary-400 hover:text-primary-600 dark:hover:text-primary-500 hover:underline hover:underline-offset-2 transition-colors"
             >Yunfi</ULink
-          >
+          >.
           <br />
           Powered by
           <ULink


### PR DESCRIPTION
Fix:

- Add a dot behind `Yunfi`

<img width="202" alt="image" src="https://github.com/yy4382/s3-image-port/assets/39331194/4cd0d8e6-73a0-47cc-ad5c-d1c190bf7406">
