### PR TITLE
style: unify style of links in footer

### DIFF
--- a/components/FooterComp.vue
+++ b/components/FooterComp.vue
@@ -38,7 +38,7 @@
           >Source at
           <ULink
             to="https://github.com/yy4382/s3-image-port"
-            inactive-class="text-primary hover:underline"
+            inactive-class="text-primary-500 dark:text-primary-400 hover:text-primary-600 dark:hover:text-primary-500 hover:underline hover:underline-offset-2 transition-colors"
             >GitHub</ULink
           ></span
         >


### PR DESCRIPTION
The original Github link had a different class than the other links. This PR fixes that.

Before:

<img width="131" alt="image" src="https://github.com/yy4382/s3-image-port/assets/39331194/24cb27e7-8b30-4a0c-8482-b0f55d428e7b">


After:

<img width="134" alt="image" src="https://github.com/yy4382/s3-image-port/assets/39331194/44bfb7ab-14cc-45a4-b8f2-8f853dad01a3">
