### PR TITLE
fix: hide part of key if key is too long (#25)

### DIFF
--- a/components/PhotoCard.vue
+++ b/components/PhotoCard.vue
@@ -1,6 +1,6 @@
 <template>
   <UCard>
-    <img :src="photo.url" preview class="w-fit m-auto overflow-visible" >
+    <img :src="photo.url" preview class="w-fit m-auto overflow-visible" />
     <template #footer>
       <div class="flex justify-between items-center gap-2">
         <div class="flex flex-col space-y-1">
@@ -10,7 +10,13 @@
           </div>
           <div class="text-xs items-center inline-flex">
             <Icon name="i-mingcute-key-2-line" class="mr-2" />
-            {{ photo.Key }}
+            <div :title="photo.Key">
+              {{
+                photo.Key.length > 24
+                  ? photo.Key.slice(0, 10) + "..." + photo.Key.slice(-10)
+                  : photo.Key
+              }}
+            </div>
           </div>
         </div>
         <div class="flex gap-2">

--- a/components/PhotoCard.vue
+++ b/components/PhotoCard.vue
@@ -3,20 +3,21 @@
     <img :src="photo.url" preview class="w-fit m-auto overflow-visible" />
     <template #footer>
       <div class="flex justify-between items-center gap-2">
-        <div class="flex flex-col space-y-1">
+        <div
+          class="flex flex-col space-y-1 flex-shrink basis-0 flex-grow min-w-0"
+        >
           <div class="text-xs items-center inline-flex">
             <Icon name="i-mingcute-time-line" class="mr-2" />
             {{ DateTime.fromISO(photo.LastModified).toFormat("yyyy-LL-dd") }}
           </div>
           <div class="text-xs items-center inline-flex">
             <Icon name="i-mingcute-key-2-line" class="mr-2" />
-            <div :title="photo.Key">
-              {{
-                photo.Key.length > 24
-                  ? photo.Key.slice(0, 10) + "..." + photo.Key.slice(-10)
-                  : photo.Key
-              }}
-            </div>
+            <span
+              :title="photo.Key"
+              class="text-ellipsis overflow-hidden whitespace-nowrap block"
+            >
+              {{ photo.Key }}
+            </span>
           </div>
         </div>
         <div class="flex gap-2">


### PR DESCRIPTION
If an image's key is too long, hide part of the key by default. You can hover to see the full key.

<img width="385" alt="image" src="https://github.com/yy4382/s3-image-port/assets/39331194/14732006-d7fd-48bb-9033-433309341877">
