### PR TITLE
Optimize the Settings Page

### DIFF
--- a/components/settings/App.vue
+++ b/components/settings/App.vue
@@ -34,6 +34,7 @@
     </div>
     <!--fuzzy search threshold-->
     <UFormGroup
+      v-if="state.enableFuzzySearch"
       :label="$t('settings.app.fuzzySearchThreshold.title')"
       :description="$t('settings.app.fuzzySearchThreshold.description')"
       name="fuzzySearchThreshold"

--- a/components/settings/App.vue
+++ b/components/settings/App.vue
@@ -1,5 +1,5 @@
 <template>
-  <UForm :state="state" :schema="appSettingsSchema" class="space-y-4">
+  <UForm :state="state" :schema="appSettingsSchema" class="space-y-4 mt-4">
     <!--auto refresh switch-->
     <div class="flex justify-between">
       <UFormGroup

--- a/components/settings/S3.vue
+++ b/components/settings/S3.vue
@@ -156,7 +156,7 @@ async function onSubmit(_event: FormSubmitEvent<Schema>) {
       <UInput v-model="state.pubUrl" />
     </UFormGroup>
 
-    <UButton type="submit">
+    <UButton type="submit" block>
       {{ $t("settings.s3.submitFormButton.title") }}
     </UButton>
   </UForm>

--- a/pages/settings.vue
+++ b/pages/settings.vue
@@ -2,7 +2,10 @@
   <UContainer class="w-full">
     <UCard class="max-w-md w-full m-auto">
       <template #header>
-        <h2>{{ $t("settings.title") }}</h2>
+        <h2 class="flex flex-row items-center gap-1">
+          <UIcon name="i-mingcute-settings-3-fill" />
+          {{ $t("settings.title") }}
+        </h2>
       </template>
       <UTabs
         :items="[


### PR DESCRIPTION
## Preview

<img width="485" alt="image" src="https://github.com/yy4382/s3-image-port/assets/39331194/b9a9f5c7-b177-4dfd-9c9a-c2c0018f81d5">

<img width="488" alt="image" src="https://github.com/yy4382/s3-image-port/assets/39331194/08a14df1-1719-41c9-a5ed-2be3ff5b23db">

## Features

- Add an icon on the card
- Show `Threshold of Fuzzy Search` only if `Enable Fuzzy Search` is enabled
- Make the `Test Connectivity` button full-width

## Fixes

- Add space between the tab switcher and the first option of the app settings

On the `S3 Settings` page there is a `Privacy Statement` which has a `margin: 16px;` while the space is missing on the `App Settings` page. This PR fixes it.