### PR TITLE
feat: select all displayed photos with one click

### DIFF
--- a/app/components/Photo/Toolbar/PhotoToolbar.vue
+++ b/app/components/Photo/Toolbar/PhotoToolbar.vue
@@ -3,6 +3,7 @@ const settings = useSettingsStore();
 const galleryState = useGalleryStateStore();
 
 const selectedPhotos = computed(() => galleryState.imageSelected);
+const hasSelectedPhotos = computed(() => selectedPhotos.value.length > 0);
 </script>
 
 <template>
@@ -10,15 +11,22 @@ const selectedPhotos = computed(() => galleryState.imageSelected);
     <PhotoToolbarRefresh />
 
     <UButton
-      v-if="selectedPhotos.length > 0"
       icon="i-mingcute-checkbox-line"
-      :label="selectedPhotos.length + ''"
+      :label="hasSelectedPhotos ? selectedPhotos.length + '' : undefined"
       variant="solid"
       color="gray"
-      @click="galleryState.clearSelectedPhotos"
+      @click="
+        () => {
+          if (hasSelectedPhotos) {
+            galleryState.clearSelectedPhotos();
+          } else {
+            galleryState.selectDisplayedPhotos();
+          }
+        }
+      "
     />
     <BaseSecondConfirm
-      v-if="selectedPhotos.length > 0"
+      v-if="hasSelectedPhotos"
       :action="
         () => {
           galleryState.deletePhoto();

--- a/app/stores/galleryState.ts
+++ b/app/stores/galleryState.ts
@@ -66,6 +66,9 @@ export const useGalleryStateStore = defineStore("galleryState", () => {
   const clearSelectedPhotos = () => {
     imageSelected.value = [];
   };
+  const selectDisplayedPhotos = () => {
+    imageSelected.value = imageDisplayed.value.map((photo) => photo.Key);
+  };
 
   async function deletePhoto(inputKeys?: string[]) {
     const keys = inputKeys ?? imageSelected.value;
@@ -92,6 +95,7 @@ export const useGalleryStateStore = defineStore("galleryState", () => {
     imageDisplayed,
     imageSelected,
     clearSelectedPhotos,
+    selectDisplayedPhotos,
     deletePhoto,
   };
 });


### PR DESCRIPTION
Related to #82

Now, click on the "tick" button on the floating panel will select all currently-displayed images (those on current page).
If any image is already selected, the button keeps the old behaviour that de-selects all images.

cc @fishhh666