### PR TITLE
feat: persist filter

### DIFF
--- a/app/stores/galleryState.ts
+++ b/app/stores/galleryState.ts
@@ -49,6 +49,7 @@ export const useGalleryStateStore = defineStore("galleryState", () => {
     searchTerm: "",
     prefix: "",
     dateRange: { start: sub(new Date(), { years: 1000 }), end: new Date() },
+    dateRangeType: "all",
     sort: { by: "key", orderIsDesc: true },
   });
 

--- a/app/utils/filterImages.ts
+++ b/app/utils/filterImages.ts
@@ -1,11 +1,12 @@
 import type { AppSettings, Photo } from "~/types";
-import { compareAsc, compareDesc } from "date-fns";
+import { compareAsc, compareDesc, sub } from "date-fns";
 import Fuse from "fuse.js";
 
 export type FilterOptions = {
   searchTerm: string;
   prefix: string;
   dateRange: { start: Date; end: Date };
+  dateRangeType: (typeof TIME_RANGES)[number]["type"] | "custom";
   sort: {
     by: "key" | "date";
     orderIsDesc: boolean;
@@ -82,4 +83,131 @@ export default function filterImages(
     return sortSearch(filteredImages, options, appSettings);
   }
   return sortTrivial(filteredImages, options.sort.by, options.sort.orderIsDesc);
+}
+
+export const ALL_TIME_RANGE: Duration = { years: 1000 };
+export const TIME_RANGES = [
+  {
+    duration: { days: 7 },
+    type: "7d",
+  },
+  {
+    duration: { days: 14 },
+    type: "14d",
+  },
+  {
+    duration: { days: 30 },
+    type: "30d",
+  },
+  {
+    duration: { months: 3 },
+    type: "3m",
+  },
+  {
+    duration: { months: 6 },
+    type: "6m",
+  },
+  {
+    duration: { years: 1 },
+    type: "1y",
+  },
+  {
+    duration: ALL_TIME_RANGE,
+    type: "all",
+  },
+] as const;
+
+export const FILTER_LOCALSTORAGE_KEY = "s3pi:filterOptions";
+
+export function loadOptions(
+  searchParam: URLSearchParams,
+  localstorage: Record<string, string>,
+): FilterOptions | undefined {
+  return (
+    loadOptionsWithType((x) => searchParam.get(x)) ??
+    loadOptionsWithType((x) => localstorage[x] ?? null)
+  );
+}
+
+function loadOptionsWithType(
+  getter: (x: string) => string | null,
+): FilterOptions | undefined {
+  let dateRangeType = getter("dateRangeType") ?? undefined;
+  const searchTerm = getter("searchTerm") ?? "";
+  const prefix = getter("prefix") ?? "";
+  let sortby = getter("sortby") ?? undefined;
+  let sortOrder = getter("sortOrder") ?? undefined;
+  if (![dateRangeType, searchTerm, prefix, sortby, sortOrder].some(Boolean)) {
+    return;
+  }
+
+  if (sortby !== "key" && sortby !== "date") {
+    sortby = "key";
+  }
+  if (sortOrder !== "asc" && sortOrder !== "desc") {
+    sortOrder = "desc";
+  }
+
+  let dateRange: FilterOptions["dateRange"] | undefined = undefined;
+
+  const dateRangeStart = getter("dateRangeStart");
+  const dateRangeEnd = getter("dateRangeEnd");
+  if (dateRangeType === "custom" && dateRangeStart && dateRangeEnd) {
+    dateRange = {
+      start: new Date(dateRangeStart),
+      end: new Date(dateRangeEnd),
+    };
+  } else if (
+    dateRangeType &&
+    (TIME_RANGES.map((r) => r.type) as string[]).includes(dateRangeType)
+  ) {
+    const duration = TIME_RANGES.find(
+      (r) => r.type === dateRangeType,
+    )!.duration;
+    dateRange = {
+      start: sub(new Date(), duration),
+      end: new Date(),
+    };
+  } else {
+    dateRangeType = "all";
+    dateRange = {
+      start: sub(new Date(), ALL_TIME_RANGE),
+      end: new Date(),
+    };
+  }
+
+  return {
+    searchTerm,
+    prefix,
+    dateRangeType: dateRangeType as FilterOptions["dateRangeType"],
+    dateRange,
+    sort: {
+      by: sortby as "key" | "date",
+      orderIsDesc: sortOrder === "desc",
+    },
+  };
+}
+
+export function saveOptions(options: FilterOptions) {
+  const toBeSaved: Record<string, string> = {};
+  const setter = (x: string, y: string | undefined) => {
+    if (!y) return;
+    toBeSaved[x] = y;
+  };
+
+  setter("searchTerm", options.searchTerm);
+  setter("prefix", options.prefix);
+  setter(
+    "dateRangeType",
+    options.dateRangeType === "all" ? undefined : options.dateRangeType,
+  );
+  if (options.dateRangeType === "custom") {
+    setter("dateRangeStart", options.dateRange.start.toISOString());
+    setter("dateRangeEnd", options.dateRange.end.toISOString());
+  }
+  setter("sortby", options.sort.by === "date" ? "date" : undefined);
+  setter("sortOrder", options.sort.orderIsDesc ? undefined : "asc");
+
+  // return and let caller (component) to update the URL
+  return toBeSaved;
 }

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -134,13 +134,13 @@
           "notAvailableOnMobile": "Sorry, Calendar not supported on mobile.",
           "calendar": {
             "labels": {
-              "last7Days": "Last 7 Days",
-              "last14Days": "Last 14 Days",
-              "last30Days": "Last 30 Days",
-              "last3Months": "Last 3 Months",
-              "last6Months": "Last 6 Months",
-              "lastYear": "Last Year",
-              "allTime": "All Time"
+              "7d": "Last 7 Days",
+              "14d": "Last 14 Days",
+              "30d": "Last 30 Days",
+              "3m": "Last 3 Months",
+              "6m": "Last 6 Months",
+              "1y": "Last Year",
+              "all": "All Time"
             }
           }
         },

--- a/i18n/locales/zh.json
+++ b/i18n/locales/zh.json
@@ -134,13 +134,13 @@
           "notAvailableOnMobile": "抱歉，Calendar 组件在移动设备上暂不可用。",
           "calendar": {
             "labels": {
-              "last7Days": "最近 7 天",
-              "last14Days": "最近 14 天",
-              "last30Days": "最近 30 天",
-              "last3Months": "最近 3 个月",
-              "last6Months": "最近 6 个月",
-              "lastYear": "最近 1 年",
-              "allTime": "最近 1000 年"
+              "7d": "最近 7 天",
+              "14d": "最近 14 天",
+              "30d": "最近 30 天",
+              "3m": "最近 3 个月",
+              "6m": "最近 6 个月",
+              "1y": "最近 1 年",
+              "all": "所有"
             }
           }
         },


### PR DESCRIPTION
Related to #82 

Now filters will be persisted in URL search params and localstorge. Every time page loads, it will reads filters from these two places.

URL search params has higher priority, so that users can use browser's bookmarks to save their filters.

cc @fishhh666