### PR TITLE
feat(upload): support clipboard image paste

### DIFF
--- a/app/components/Upload/UploadWrapper.vue
+++ b/app/components/Upload/UploadWrapper.vue
@@ -53,6 +53,33 @@ const uploadProgress = ref(0);
 const uploadProgressMax = ref(0);
 const showProgress = ref(false);
 
+const handlePaste = async (event: ClipboardEvent) => {
+  if (!event.clipboardData) return;
+
+  const items = event.clipboardData.items;
+  if (!items) return;
+
+  for (const item of items) {
+    if (item.kind === "file" && item.type.startsWith("image/")) {
+      const file = item.getAsFile();
+      if (file) {
+        fileList.value.push(file);
+        toast.add({
+          title: t("upload.fileUploader.clipboardSuccess"),
+        });
+      }
+    }
+  }
+};
+
+onMounted(() => {
+  window.addEventListener("paste", handlePaste);
+});
+
+onUnmounted(() => {
+  window.removeEventListener("paste", handlePaste);
+});
+
 const upload = async () => {
   uploading.value = true;
   uploadProgressMax.value = fileList.value.length;

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -70,6 +70,7 @@
   },
   "upload": {
     "title": "Upload",
+    "clipboardSuccess": "Successfully read image from clipboard",
     "fileUploader": {
       "dropZone": {
         "part1": "Drop files here or ",

--- a/i18n/locales/zh.json
+++ b/i18n/locales/zh.json
@@ -71,6 +71,7 @@
   "upload": {
     "title": "上传",
     "fileUploader": {
+      "clipboardSuccess": "读取剪切板图片成功",
       "dropZone": {
         "part1": "拖放文件到这里，或者",
         "part2": "点击上传"


### PR DESCRIPTION
This PR adds support for pasting images directly from the clipboard into the upload component. It detects clipboard events and extracts image files (e.g., PNG, JPEG, GIF, WebP) for uploading.

Changes
Added a handlePaste method to process ClipboardEvent.
Extracted image/* files from clipboardData.items.
Appended the pasted images to the existing file list.
Displayed a success message upon successful paste detection.

Test Plan
Copy an image and paste it into the upload area.
Verify that PNG, JPEG, GIF, and WebP images are correctly recognized and added to the upload list.
Ensure no impact on existing upload functionality.

Additional Notes
Please review and let me know if any improvements are needed. 🚀