### PR TITLE
feat: Add native Backblaze B2 support

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -32,6 +32,9 @@
     },
     "s3Settings": {
       "title": "S3",
+      "provider": "Provider",
+      "s3Compatible": "S3 Compatible",
+      "b2": "Backblaze B2",
       "endpoint": "Endpoint",
       "endpointDesc": "S3 endpoint",
       "bucket": "Bucket Name",

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -32,6 +32,9 @@
     },
     "s3Settings": {
       "title": "S3",
+      "provider": "提供商",
+      "s3Compatible": "S3 兼容",
+      "b2": "Backblaze B2",
       "endpoint": "端点",
       "endpointDesc": "S3 端点",
       "bucket": "存储桶名称",

--- a/apps/web/src/modules/settings/s3/b2.tsx
+++ b/apps/web/src/modules/settings/s3/b2.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import { useTranslations, useLocale } from "next-intl";
+import { focusAtom } from "jotai-optics";
+import {
+  s3SettingsAtom,
+  s3SettingsSchema,
+  type S3Options,
+} from "../settings-store";
+import { FormEntryTextAtom } from "@/components/ui/form-entry-validate";
+import { useAtom } from "jotai";
+import { useEffect } from "react";
+
+// https://gist.github.com/trvrb/43778077ba54274d1a21112916a89c02
+const keyIdToRegion: Record<string, string> = {
+  "000": "us-west-000",
+  "001": "us-west-001",
+  "002": "us-west-002",
+  "003": "eu-central-003",
+  "004": "us-west-004",
+  "005": "us-east-005",
+};
+
+function getS3Part(
+  opt: keyof Pick<
+    S3Options,
+    "bucket" | "accKeyId" | "secretAccKey" | "pubUrl"
+  >,
+) {
+  return {
+    schema: s3SettingsSchema.shape[opt],
+    atom: focusAtom(s3SettingsAtom, (optic) => optic.prop(opt)),
+  };
+}
+
+export function B2Form() {
+  const t = useTranslations("settings.s3Settings");
+  const locale = useLocale();
+  const [s3Settings, setS3Settings] = useAtom(s3SettingsAtom);
+  const { accKeyId } = s3Settings;
+
+  useEffect(() => {
+    if (accKeyId && accKeyId.length >= 3) {
+      const keyIdPrefix = accKeyId.substring(0, 3);
+      const region = keyIdToRegion[keyIdPrefix];
+      if (region) {
+        setS3Settings((prev) => ({
+          ...prev,
+          region,
+          endpoint: `https://s3.${region}.backblazeb2.com`,
+          forcePathStyle: true,
+        }));
+      }
+    }
+  }, [accKeyId, setS3Settings]);
+
+  return (
+    <>
+      <div className="grid gap-2 grid-cols-2 items-start">
+        <FormEntryTextAtom
+          {...getS3Part("bucket")}
+          title={t("bucket")}
+          description={t("bucketDesc")}
+          placeholder="my-bucket"
+          tooltipStyleDescription
+        />
+      </div>
+      <FormEntryTextAtom
+        {...getS3Part("accKeyId")}
+        title={t("accessKey")}
+        description={t("accessKeyDesc")}
+        placeholder="XXXXXXXX"
+        tooltipStyleDescription
+        password
+      />
+      <FormEntryTextAtom
+        {...getS3Part("secretAccKey")}
+        title={t("secretKey")}
+        description={t("secretKeyDesc")}
+        placeholder="XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+        tooltipStyleDescription
+        password
+      />
+      <FormEntryTextAtom
+        {...getS3Part("pubUrl")}
+        title={t("publicUrl")}
+        description={t.rich("publicUrlDesc", {
+          mono: (chunks) => <span className="font-mono">{chunks}</span>,
+          more: (chunks) => (
+            <a
+              href={
+                new URL(
+                  locale === "zh"
+                    ? "/zh/guide/getting-started#public-url"
+                    : "/guide/getting-started#public-url",
+                  process.env.NEXT_PUBLIC_DOCS_ORIGIN ??
+                    "https://docs.imageport.app",
+                ).toString()
+              }
+              target="_blank"
+              className="hover:text-primary underline-offset-2 underline"
+            >
+              {chunks}
+            </a>
+          ),
+        })}
+        placeholder="https://example1.com"
+      />
+    </>
+  );
+}

--- a/apps/web/src/modules/settings/s3/s3.test.tsx
+++ b/apps/web/src/modules/settings/s3/s3.test.tsx
@@ -304,4 +304,30 @@ describe("S3Settings", () => {
       expect(getConfigInAtom().pubUrl).toEqual("not a valid url");
     });
   });
+
+  describe("B2 provider", () => {
+    it("should derive region and endpoint from key id", async () => {
+      render(
+        <>
+          <S3Settings />
+          <S3SettingsString />
+        </>,
+      );
+
+      // Switch to B2 provider
+      fireEvent.mouseDown(screen.getByRole("combobox"));
+      fireEvent.click(await screen.findByText("Backblaze B2"));
+
+      const input = screen.getByLabelText("Access Key");
+      fireEvent.change(input, { target: { value: "002key" } });
+
+      await screen.findByDisplayValue("002key");
+
+      expect(getConfigInAtom().region).toEqual("us-west-002");
+      expect(getConfigInAtom().endpoint).toEqual(
+        "https://s3.us-west-002.backblazeb2.com",
+      );
+      expect(getConfigInAtom().forcePathStyle).toEqual(true);
+    });
+  });
 });

--- a/apps/web/src/modules/settings/s3/s3.tsx
+++ b/apps/web/src/modules/settings/s3/s3.tsx
@@ -3,6 +3,7 @@
 import { useLocale, useTranslations } from "next-intl";
 import { focusAtom } from "jotai-optics";
 import {
+  s3ProviderAtom,
   s3SettingsAtom,
   s3SettingsSchema,
   type S3Options,
@@ -13,6 +14,16 @@ import {
 } from "@/components/ui/form-entry-validate";
 import { S3Validation } from "./s3-validation";
 import { ExternalLink } from "lucide-react";
+import { useAtom } from "jotai";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { FormEntry } from "@/components/ui/form-entry";
+import { B2Form } from "./b2";
 
 function getS3Part(opt: keyof Omit<S3Options, "forcePathStyle">) {
   return {
@@ -21,9 +32,99 @@ function getS3Part(opt: keyof Omit<S3Options, "forcePathStyle">) {
   };
 }
 
+function S3CompatibleForm() {
+  const t = useTranslations("settings.s3Settings");
+  const locale = useLocale();
+  return (
+    <>
+      <FormEntryTextAtom
+        {...getS3Part("endpoint")}
+        title={t("endpoint")}
+        description={t("endpointDesc")}
+        placeholder="https://example.com"
+        tooltipStyleDescription
+      />
+      <div className="grid gap-2 grid-cols-2 items-start">
+        <FormEntryTextAtom
+          {...getS3Part("bucket")}
+          title={t("bucket")}
+          description={t("bucketDesc")}
+          placeholder="my-bucket"
+          tooltipStyleDescription
+        />
+        <FormEntryTextAtom
+          {...getS3Part("region")}
+          title={t("region")}
+          description={t("regionDesc")}
+          placeholder="us-east-1"
+          tooltipStyleDescription
+        />
+      </div>
+      <FormEntryTextAtom
+        {...getS3Part("accKeyId")}
+        title={t("accessKey")}
+        description={t("accessKeyDesc")}
+        placeholder="XXXXXXXX"
+        tooltipStyleDescription
+        password
+      />
+      <FormEntryTextAtom
+        {...getS3Part("secretAccKey")}
+        title={t("secretKey")}
+        description={t("secretKeyDesc")}
+        placeholder="XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+        tooltipStyleDescription
+        password
+      />
+      <FormEntrySwitchAtom
+        atom={focusAtom(s3SettingsAtom, (optic) =>
+          optic.prop("forcePathStyle"),
+        )}
+        title={t("pathStyle")}
+        description={t.rich("pathStyleDesc", {
+          more: (chunks) => (
+            <a
+              href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html"
+              target="_blank"
+              className="hover:text-primary underline-offset-2 underline"
+            >
+              {chunks}
+            </a>
+          ),
+        })}
+      />
+      <FormEntryTextAtom
+        {...getS3Part("pubUrl")}
+        title={t("publicUrl")}
+        description={t.rich("publicUrlDesc", {
+          mono: (chunks) => <span className="font-mono">{chunks}</span>,
+          more: (chunks) => (
+            <a
+              href={new URL(
+                locale === "zh"
+                  ? "/zh/guide/getting-started#public-url"
+                  : "/guide/getting-started#public-url",
+                process.env.NEXT_PUBLIC_DOCS_ORIGIN ??
+                  "https://docs.imageport.app",
+              ).toString()}
+              target="_blank"
+              className="hover:text-primary underline-offset-2 underline"
+            >
+              {chunks}
+            </a>
+          ),
+        })}
+        placeholder="https://example1.com"
+      />
+    </>
+  );
+}
+
 function S3Settings() {
   const t = useTranslations("settings.s3Settings");
   const locale = useLocale();
+  const [provider, setProvider] = useAtom(s3ProviderAtom);
+
   return (
     <div>
       <div className="grid gap-6">
@@ -45,85 +146,25 @@ function S3Settings() {
             <ExternalLink className="h-4 w-4" />
           </a>
         </div>
-        <FormEntryTextAtom
-          {...getS3Part("endpoint")}
-          title={t("endpoint")}
-          description={t("endpointDesc")}
-          placeholder="https://example.com"
-          tooltipStyleDescription
-        />
-        <div className="grid gap-2 grid-cols-2 items-start">
-          <FormEntryTextAtom
-            {...getS3Part("bucket")}
-            title={t("bucket")}
-            description={t("bucketDesc")}
-            placeholder="my-bucket"
-            tooltipStyleDescription
-          />
-          <FormEntryTextAtom
-            {...getS3Part("region")}
-            title={t("region")}
-            description={t("regionDesc")}
-            placeholder="us-east-1"
-            tooltipStyleDescription
-          />
-        </div>
-        <FormEntryTextAtom
-          {...getS3Part("accKeyId")}
-          title={t("accessKey")}
-          description={t("accessKeyDesc")}
-          placeholder="XXXXXXXX"
-          tooltipStyleDescription
-          password
-        />
-        <FormEntryTextAtom
-          {...getS3Part("secretAccKey")}
-          title={t("secretKey")}
-          description={t("secretKeyDesc")}
-          placeholder="XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
-          tooltipStyleDescription
-          password
-        />
-        <FormEntrySwitchAtom
-          atom={focusAtom(s3SettingsAtom, (optic) =>
-            optic.prop("forcePathStyle"),
-          )}
-          title={t("pathStyle")}
-          description={t.rich("pathStyleDesc", {
-            more: (chunks) => (
-              <a
-                href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html"
-                target="_blank"
-                className="hover:text-primary underline-offset-2 underline"
-              >
-                {chunks}
-              </a>
-            ),
-          })}
-        />
-        <FormEntryTextAtom
-          {...getS3Part("pubUrl")}
-          title={t("publicUrl")}
-          description={t.rich("publicUrlDesc", {
-            mono: (chunks) => <span className="font-mono">{chunks}</span>,
-            more: (chunks) => (
-              <a
-                href={new URL(
-                  locale === "zh"
-                    ? "/zh/guide/getting-started#public-url"
-                    : "/guide/getting-started#public-url",
-                  process.env.NEXT_PUBLIC_DOCS_ORIGIN ??
-                    "https://docs.imageport.app",
-                ).toString()}
-                target="_blank"
-                className="hover:text-primary underline-offset-2 underline"
-              >
-                {chunks}
-              </a>
-            ),
-          })}
-          placeholder="https://example1.com"
-        />
+
+        <FormEntry title={t("provider")}>
+          <Select
+            value={provider}
+            onValueChange={(v) => setProvider(v as "s3" | "b2")}
+          >
+            <SelectTrigger>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="s3">{t("s3Compatible")}</SelectItem>
+              <SelectItem value="b2">{t("b2")}</SelectItem>
+            </SelectContent>
+          </Select>
+        </FormEntry>
+
+        {provider === "s3" && <S3CompatibleForm />}
+        {provider === "b2" && <B2Form />}
+
         <S3Validation />
       </div>
     </div>

--- a/apps/web/src/modules/settings/settings-store.ts
+++ b/apps/web/src/modules/settings/settings-store.ts
@@ -5,6 +5,9 @@ import { keyTemplateSchema } from "./upload/KeyTemplate";
 import z from "zod/v4";
 import { compressOptionSchema } from "@/lib/utils/imageCompress";
 import { atom } from "jotai";
+import { atomWithStorage } from "jotai/utils";
+
+export const s3ProviderAtom = atomWithStorage<"s3" | "b2">("S3_PROVIDER", "s3");
 
 export const s3SettingsSchema = z.object({
   endpoint: z.url(),


### PR DESCRIPTION
This adds native support for Backblaze B2 as a storage provider.

A new provider selection dropdown is added to the S3 settings page, allowing users to choose between 'S3 Compatible' and 'Backblaze B2'.

When 'Backblaze B2' is selected, a simplified form is shown that only requires the Bucket Name, Application Key ID, and Secret Application Key.

The region and endpoint are automatically derived from the Application Key ID, and `forcePathStyle` is set to `true`.