### PR TITLE
feat: add include path feature for S3 settings

### DIFF
--- a/apps/web/content/docs/settings-reference.mdx
+++ b/apps/web/content/docs/settings-reference.mdx
@@ -26,6 +26,21 @@ For example, if an image's path in the bucket is `i/2024/05/29/name.jpg`, and yo
 
 If you directly use the "public bucket" feature of some S3-compatible services, the same principle applies. For example, for Cloudflare R2, it should look like `https://pub-<bunch-of-characters>.r2.dev`. For Tencent Cloud COS, it should look like `https://<BucketName-APPID>.cos.<Region>.myqcloud.com`
 
+### Include Path [#include-path]
+
+Optional path prefix to filter which objects are listed from your S3 bucket. This is useful when your bucket contains non-image objects or when you want to organize images in specific paths.
+
+When you specify an include path (e.g., `i/`), only objects starting with that prefix will be fetched from S3. This filtering happens at the API level, reducing data transfer and improving performance.
+
+**Examples:**
+
+- Leave empty to list all objects in the bucket
+- `i/` - only list objects starting with "i/"
+- `images/` - only list objects starting with "images/"
+- `2024/photos/` - only list objects starting with "2024/photos/"
+
+**Note:** This setting filters objects when they are fetched from S3. Changing this value will automatically refresh the gallery to show only the filtered objects.
+
 ## Upload Settings [#upload-settings]
 
 ### Key Template [#key-template]

--- a/apps/web/content/docs/settings-reference.zh.mdx
+++ b/apps/web/content/docs/settings-reference.zh.mdx
@@ -24,7 +24,22 @@ title: 设置参考
 
 例如，一张图片在储存桶中的路径是 `i/2024/05/29/name.jpg`，而你可以通过 `https://i.yfi.moe/i/2024/05/29/name.jpg` 这个链接直接（不需要验证地）访问到它，那么 `https://i.yfi.moe/` 就是你需要填写的 Public URL.
 
-如果你直接使用了某些 S3 兼容服务的“公开储存桶”功能，也是同理。例如，对于 Cloudflare R2，它应该形如 `https://pub-<一堆字符>.r2.dev`。对于腾讯云 COS，应该形如 `https://<BucketName-APPID>.cos.<Region>.myqcloud.com`
+如果你直接使用了某些 S3 兼容服务的"公开储存桶"功能，也是同理。例如，对于 Cloudflare R2，它应该形如 `https://pub-<一堆字符>.r2.dev`。对于腾讯云 COS，应该形如 `https://<BucketName-APPID>.cos.<Region>.myqcloud.com`
+
+### 包含路径 [#include-path]
+
+可选的路径前缀，用于过滤从 S3 储存桶中列出的对象。当储存桶包含非图片对象或需要在特定路径下组织图片时非常有用。
+
+当你指定包含路径（例如 `i/`）时，只会从 S3 获取以该前缀开头的对象。此过滤发生在 API 级别，可减少数据传输并提高性能。
+
+**示例：**
+
+- 留空以列出储存桶中的所有对象
+- `i/` - 仅列出以 "i/" 开头的对象
+- `images/` - 仅列出以 "images/" 开头的对象
+- `2024/photos/` - 仅列出以 "2024/photos/" 开头的对象
+
+**注意：** 此设置会在从 S3 获取对象时进行过滤。更改此值将自动刷新画廊以仅显示过滤后的对象。
 
 ## 上传设置 [#upload-settings]
 

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -262,7 +262,8 @@
     },
     "grid": {
       "noPhotosFound": "No photos found",
-      "loadPhotos": "Load Photos"
+      "loadPhotos": "Load Photos",
+      "includePathTip": "You are only listing photos from path <mono>{path}</mono> since you have set an include path filter. This might be why no photos are found. If this is incorrect, please update it in the <link>S3 settings</link>."
     },
     "filter": {
       "filterOptions": "Filter Options",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -57,7 +57,9 @@
       "pathStyle": "Use Path Style API",
       "pathStyleDesc": "Force using the deprecated <more>path style API</more>.",
       "publicUrl": "Public URL",
-      "publicUrlDesc": "The access url for the public bucket. <mono>public-url/object-path</mono> should be able to access the object in bucket. Learn more at <more>docs</more>."
+      "publicUrlDesc": "The access url for the public bucket. <mono>public-url/object-path</mono> should be able to access the object in bucket. Learn more at <more>docs</more>.",
+      "includePath": "Include Path",
+      "includePathDesc": "Optional path prefix to filter objects (e.g., \"i/\" to only list objects starting with \"i/\"). Leave empty to list all objects."
     },
     "s3Validation": {
       "status": {

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -262,7 +262,8 @@
     },
     "grid": {
       "noPhotosFound": "未找到照片",
-      "loadPhotos": "加载照片"
+      "loadPhotos": "加载照片",
+      "includePathTip": "您仅列出路径 <mono>{path}</mono> 下的照片，因为您已设置了包含路径过滤器。这可能是为什么未找到照片。如果这不正确，请在<link>S3 设置</link>中更新。"
     },
     "filter": {
       "filterOptions": "过滤选项",

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -57,7 +57,9 @@
       "pathStyle": "使用路径形式 API",
       "pathStyleDesc": "强制使用已经被废弃的<more>路径形式 API</more>。",
       "publicUrl": "公共 URL",
-      "publicUrlDesc": "公共存储桶的访问URL。<mono>public-url/object-path</mono>应该能够访问存储桶中的对象。\n在<more>文档</more>中了解更多。"
+      "publicUrlDesc": "公共存储桶的访问URL。<mono>public-url/object-path</mono>应该能够访问存储桶中的对象。\n在<more>文档</more>中了解更多。",
+      "includePath": "包含路径",
+      "includePathDesc": "可选的路径前缀，用于过滤对象（例如 \"i/\" 仅列出以 \"i/\" 开头的对象）。留空以列出所有对象。"
     },
     "s3Validation": {
       "status": {

--- a/apps/web/src/lib/s3/image-s3-client.ts
+++ b/apps/web/src/lib/s3/image-s3-client.ts
@@ -131,6 +131,7 @@ class ImageS3Client {
     const command = new ListObjectsV2Command({
       Bucket: this.bucket,
       ContinuationToken: NextContinuationToken,
+      ...(this.config.includePath && { Prefix: this.config.includePath }),
     });
     const response = await this.client.send(command);
 

--- a/apps/web/src/modules/gallery/GalleryContent/PhotoGrid.tsx
+++ b/apps/web/src/modules/gallery/GalleryContent/PhotoGrid.tsx
@@ -19,6 +19,8 @@ import { PhotoItem } from "./PhotoItem/PhotoItem";
 import { useTranslations } from "use-intl";
 import { Loader2 } from "lucide-react";
 import { selectedPhotosAtom, currentPageAtom } from "@/stores/atoms/gallery";
+import { s3SettingsAtom } from "@/stores/atoms/settings";
+import { Link } from "@tanstack/react-router";
 
 export function PhotoGrid() {
   const photos = useAtomValue(showingPhotosAtom);
@@ -99,6 +101,9 @@ export function PhotoGrid() {
 function PhotoGridEmpty() {
   const t = useTranslations("gallery.grid");
   const { fetchPhotoList, isLoading } = useFetchPhotoList();
+  const s3Settings = useAtomValue(s3SettingsAtom);
+  const hasIncludePath = s3Settings.includePath.length > 0;
+
   return (
     <div className="flex flex-col items-center justify-center w-full h-64 p-8 bg-muted/20 rounded-lg border border-dashed border-muted-foreground/30">
       <div className="flex flex-col items-center gap-2 mb-4">
@@ -108,6 +113,24 @@ function PhotoGridEmpty() {
         <p className="text-lg text-muted-foreground text-center">
           {t("noPhotosFound")}
         </p>
+        {hasIncludePath && (
+          <p className="text-sm text-muted-foreground/80 text-center max-w-md">
+            {t.rich("includePathTip", {
+              path: s3Settings.includePath,
+              mono: (chunks) => <span className="font-mono">{chunks}</span>,
+              link: (chunks) => (
+                <Link
+                  from="/$locale/gallery"
+                  to="/$locale/settings/s3"
+                  params={(prev) => ({ locale: prev.locale })}
+                  className="underline underline-offset-2 hover:text-primary"
+                >
+                  {chunks}
+                </Link>
+              ),
+            })}
+          </p>
+        )}
       </div>
       <Button
         variant="outline"

--- a/apps/web/src/modules/settings/s3/s3.test.tsx
+++ b/apps/web/src/modules/settings/s3/s3.test.tsx
@@ -323,4 +323,52 @@ describe("S3Settings", () => {
       expect(getConfigInAtom().pubUrl).toEqual("not a valid url");
     });
   });
+
+  describe("include path", () => {
+    it("defaults to empty string", () => {
+      render(
+        <>
+          <S3Settings />
+          <S3SettingsString />
+        </>,
+      );
+      expect(
+        screen.getByLabelText("Include Path").getAttribute("value"),
+      ).toEqual("");
+      expect(getConfigInAtom().includePath).toEqual("");
+    });
+    it("can be set", () => {
+      render(
+        <>
+          <S3Settings />
+          <S3SettingsString />
+        </>,
+      );
+      const input = screen.getByLabelText("Include Path");
+      fireEvent.change(input, { target: { value: "i/" } });
+      expect(input.getAttribute("value")).toEqual("i/");
+      expect(getConfigInAtom().includePath).toEqual("i/");
+    });
+    it("can be set to various path prefixes", () => {
+      render(
+        <>
+          <S3Settings />
+          <S3SettingsString />
+        </>,
+      );
+      const input = screen.getByLabelText("Include Path");
+
+      fireEvent.change(input, { target: { value: "images/" } });
+      expect(input.getAttribute("value")).toEqual("images/");
+      expect(getConfigInAtom().includePath).toEqual("images/");
+
+      fireEvent.change(input, { target: { value: "2024/photos/" } });
+      expect(input.getAttribute("value")).toEqual("2024/photos/");
+      expect(getConfigInAtom().includePath).toEqual("2024/photos/");
+
+      fireEvent.change(input, { target: { value: "" } });
+      expect(input.getAttribute("value")).toEqual("");
+      expect(getConfigInAtom().includePath).toEqual("");
+    });
+  });
 });

--- a/apps/web/src/modules/settings/s3/s3.tsx
+++ b/apps/web/src/modules/settings/s3/s3.tsx
@@ -32,15 +32,9 @@ function S3SettingsTsForm() {
     },
     listeners: {
       onChange: ({ formApi }) => {
-        const newValues = formApi.state.values;
         startTransition(() => {
-          setValues((prev) => {
-            // if includePath changes, set gallery dirty to trigger a refresh
-            if (newValues.includePath !== prev.includePath) {
-              setGalleryDirty();
-            }
-            return newValues;
-          });
+          setValues(formApi.state.values);
+          setGalleryDirty(); // All changes to s3 settings should trigger a gallery refresh
         });
       },
     },

--- a/apps/web/src/modules/settings/s3/s3.tsx
+++ b/apps/web/src/modules/settings/s3/s3.tsx
@@ -18,11 +18,13 @@ import { ClientOnly, Link } from "@tanstack/react-router";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useAppForm } from "@/components/misc/field/field-context";
 import { startTransition } from "react";
+import { setGalleryDirtyAtom } from "@/stores/atoms/gallery";
 
 function S3SettingsTsForm() {
   const t = useTranslations("settings.s3Settings");
   const defaultValues = useAtomValue(s3SettingsAtom);
   const setValues = useSetAtom(s3SettingsAtom);
+  const setGalleryDirty = useSetAtom(setGalleryDirtyAtom);
   const form = useAppForm({
     defaultValues,
     validators: {
@@ -30,8 +32,15 @@ function S3SettingsTsForm() {
     },
     listeners: {
       onChange: ({ formApi }) => {
+        const newValues = formApi.state.values;
         startTransition(() => {
-          setValues(formApi.state.values);
+          setValues((prev) => {
+            // if includePath changes, set gallery dirty to trigger a refresh
+            if (newValues.includePath !== prev.includePath) {
+              setGalleryDirty();
+            }
+            return newValues;
+          });
         });
       },
     },
@@ -145,6 +154,15 @@ function S3SettingsTsForm() {
                   </Link>
                 ),
               })}
+            />
+          )}
+        />
+        <form.AppField
+          name="includePath"
+          children={(field) => (
+            <field.TextField
+              label={t("includePath")}
+              description={t("includePathDesc")}
             />
           )}
         />

--- a/apps/web/src/stores/schemas/settings/v3.ts
+++ b/apps/web/src/stores/schemas/settings/v3.ts
@@ -11,6 +11,7 @@ export const getDefaultOptions = (): z.infer<typeof optionsSchema> => {
       secretAccKey: "",
       forcePathStyle: false,
       pubUrl: "",
+      includePath: "",
     },
     upload: {
       keyTemplate: defaultKeyTemplate,
@@ -31,6 +32,7 @@ const s3SettingsSchema = z.object({
   secretAccKey: z.string().min(1, "Cannot be empty"),
   forcePathStyle: z.boolean(),
   pubUrl: z.url(),
+  includePath: z.string(),
 });
 
 const s3SettingsSchemaForLoad = z.object({
@@ -41,6 +43,7 @@ const s3SettingsSchemaForLoad = z.object({
   secretAccKey: z.string().catch(""),
   forcePathStyle: z.boolean().catch(false),
   pubUrl: z.string().catch(""),
+  includePath: z.string().catch(""),
 });
 
 const compressOptionSchema = z.union([


### PR DESCRIPTION
Implements #114

- Introduced an optional path prefix to filter objects listed from the S3 bucket, enhancing performance and organization.
- Updated documentation and translations to reflect the new include path functionality.
- Modified the S3 client to support fetching objects based on the specified include path.
- Implemented UI changes to allow users to set the include path in the settings form.
