### PR TITLE
feat(i18n): persist user locale preference and auto-redirect on root

### DIFF
--- a/apps/web/src/components/header/LocaleSwitcher.tsx
+++ b/apps/web/src/components/header/LocaleSwitcher.tsx
@@ -1,6 +1,11 @@
 "use client";
 
+import { ClientOnly, useNavigate } from "@tanstack/react-router";
+import { CheckIcon, Globe } from "lucide-react";
+import { useEffect } from "react";
 import { useLocale } from "use-intl";
+import { localeLocalNames } from "@/i18n/routing";
+import { persistLocale } from "@/lib/locale";
 import { Button } from "../ui/button";
 import {
   DropdownMenu,
@@ -8,9 +13,6 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "../ui/dropdown-menu";
-import { CheckIcon, Globe } from "lucide-react";
-import { localeLocalNames } from "@/i18n/routing";
-import { useNavigate, ClientOnly } from "@tanstack/react-router";
 
 function LocaleSwitcherWrapper() {
   return (
@@ -38,6 +40,10 @@ function LocaleSwitcher() {
     { value: "en", label: localeLocalNames.en },
     { value: "zh", label: localeLocalNames.zh },
   ];
+
+  useEffect(() => {
+    persistLocale(locale);
+  }, [locale]);
 
   return (
     <DropdownMenu>

--- a/apps/web/src/components/header/LocaleSwitcher.tsx
+++ b/apps/web/src/components/header/LocaleSwitcher.tsx
@@ -2,7 +2,6 @@
 
 import { ClientOnly, useNavigate } from "@tanstack/react-router";
 import { CheckIcon, Globe } from "lucide-react";
-import { useEffect } from "react";
 import { useLocale } from "use-intl";
 import { localeLocalNames } from "@/i18n/routing";
 import { persistLocale } from "@/lib/locale";
@@ -28,6 +27,7 @@ function LocaleSwitcher() {
   const navigate = useNavigate();
 
   const handleLocaleChange = (newLocale: string) => {
+    persistLocale(newLocale);
     navigate({
       to: ".",
       reloadDocument: true,
@@ -40,10 +40,6 @@ function LocaleSwitcher() {
     { value: "en", label: localeLocalNames.en },
     { value: "zh", label: localeLocalNames.zh },
   ];
-
-  useEffect(() => {
-    persistLocale(locale);
-  }, [locale]);
 
   return (
     <DropdownMenu>

--- a/apps/web/src/i18n/routing.ts
+++ b/apps/web/src/i18n/routing.ts
@@ -6,10 +6,9 @@ export const routing = {
   defaultLocale: "en",
 } as const;
 
-export const localeLocalNames: Record<
-  (typeof routing.locales)[number],
-  string
-> = {
+export type LocaleType = (typeof routing.locales)[number];
+
+export const localeLocalNames: Record<LocaleType, string> = {
   en: "English",
   zh: "中文",
 } as const;

--- a/apps/web/src/lib/locale/index.ts
+++ b/apps/web/src/lib/locale/index.ts
@@ -1,15 +1,15 @@
+import { z } from "zod";
 import { type LocaleType, routing } from "@/i18n/routing";
 
 /** @description Storage key for persisted locale preference */
-export const PERSISTED_LOCALE_KEY = "SETTINGS_LOCALE";
+export const PERSISTED_LOCALE_KEY = "s3ip:locale";
+
+const localeSchema = z.enum(routing.locales);
 
 /** @description Retrieve persisted locale, defaults to `routing.defaultLocale` */
 export const getPersistedLocale = (): LocaleType => {
-  const cached = localStorage.getItem(PERSISTED_LOCALE_KEY) as LocaleType;
-  if (!cached) {
-    return routing.defaultLocale;
-  }
-  return routing.locales.includes(cached) ? cached : routing.defaultLocale;
+  const cached = localStorage.getItem(PERSISTED_LOCALE_KEY);
+  return localeSchema.catch(routing.defaultLocale).parse(cached);
 };
 
 /** @description Persist locale preference to local storage */

--- a/apps/web/src/lib/locale/index.ts
+++ b/apps/web/src/lib/locale/index.ts
@@ -1,0 +1,18 @@
+import { type LocaleType, routing } from "@/i18n/routing";
+
+/** @description Storage key for persisted locale preference */
+export const PERSISTED_LOCALE_KEY = "SETTINGS_LOCALE";
+
+/** @description Retrieve persisted locale, defaults to `routing.defaultLocale` */
+export const getPersistedLocale = (): LocaleType => {
+  const cached = localStorage.getItem(PERSISTED_LOCALE_KEY) as LocaleType;
+  if (!cached) {
+    return routing.defaultLocale;
+  }
+  return routing.locales.includes(cached) ? cached : routing.defaultLocale;
+};
+
+/** @description Persist locale preference to local storage */
+export const persistLocale = (locale: string) => {
+  localStorage.setItem(PERSISTED_LOCALE_KEY, locale);
+};

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -1,9 +1,10 @@
 import { createFileRoute, Navigate } from "@tanstack/react-router";
+import { getPersistedLocale } from "@/lib/locale";
 
 export const Route = createFileRoute("/")({
   component: RouteComponent,
 });
 
 function RouteComponent() {
-  return <Navigate to="/$locale" params={{ locale: "en" }} />;
+  return <Navigate to="/$locale" params={{ locale: getPersistedLocale() }} />;
 }


### PR DESCRIPTION
feat(i18n): persist locale preference in local storage

Add locale persistence functionality to remember user's language preference.
When users visit the root path, they will be automatically redirected to
their previously selected locale instead of the default.

Changes:
- Add `getPersistedLocale` and `persistLocale` utilities in lib/locale
- Update LocaleSwitcher to persist locale on change
- Redirect root path based on persisted locale preference