### PR TITLE
fix(settings): prevent keyboard events from being captured by Dropdow…

### DIFF
--- a/apps/web/src/modules/settings/profiles/profiles.tsx
+++ b/apps/web/src/modules/settings/profiles/profiles.tsx
@@ -118,7 +118,12 @@ function ProfileItem({
                 }
               }}
             >
-              <Input defaultValue={name} name="input" className="w-40" />
+              <Input
+                defaultValue={name}
+                name="input"
+                className="w-40"
+                onKeyDown={(e) => e.stopPropagation()}
+              />
               <Button type="submit" size="sm">
                 {t("update")}
               </Button>


### PR DESCRIPTION
fix(settings): fix keyboard events being captured during profile rename

Prevent keyboard events from bubbling to DropdownMenu which was intercepting
input and causing profile rename to fail

<img width="403" height="236" alt="image" src="https://github.com/user-attachments/assets/6abc2da6-fecc-49b0-a405-824af6f18786" />