### PR TITLE
Add migration banner for S3 Image Port v2

### DIFF
--- a/app/app.vue
+++ b/app/app.vue
@@ -8,6 +8,7 @@
   ></div>
   <ClientOnly>
     <div class="min-h-screen flex flex-col dark:bg-surface-800 gap-4">
+      <MigrationBanner />
       <NavMenu />
       <NuxtPage
         class="flex-grow"

--- a/app/components/MigrationBanner.vue
+++ b/app/components/MigrationBanner.vue
@@ -1,0 +1,45 @@
+<template>
+  <div
+    v-if="visible"
+    class="w-full bg-primary-50 dark:bg-primary-950 border-b border-primary-200 dark:border-primary-800 px-4 py-2"
+  >
+    <UContainer class="flex items-center justify-between gap-2">
+      <p class="text-sm text-primary-800 dark:text-primary-200 flex-1 text-center">
+        {{ $t("migrationBanner.message") }}
+        <ULink
+          href="https://imageport.app"
+          target="_blank"
+          class="font-semibold underline hover:opacity-80"
+        >imageport.app</ULink>
+        {{ $t("migrationBanner.guide") }}
+        <ULink
+          href="https://docs.imageport.app/docs/migrate-from-v1"
+          target="_blank"
+          class="font-semibold underline hover:opacity-80"
+        >{{ $t("migrationBanner.guideLink") }}</ULink>
+      </p>
+      <UButton
+        icon="i-mingcute-close-fill"
+        size="xs"
+        color="primary"
+        variant="ghost"
+        square
+        :aria-label="$t('migrationBanner.dismiss')"
+        @click="dismiss"
+      />
+    </UContainer>
+  </div>
+</template>
+
+<script setup lang="ts">
+const visible = ref(true);
+
+onMounted(() => {
+  visible.value = localStorage.getItem("migration-banner-dismissed") !== "true";
+});
+
+function dismiss() {
+  visible.value = false;
+  localStorage.setItem("migration-banner-dismissed", "true");
+}
+</script>

--- a/app/components/MigrationBanner.vue
+++ b/app/components/MigrationBanner.vue
@@ -13,7 +13,7 @@
         >imageport.app</ULink>
         {{ $t("migrationBanner.guide") }}
         <ULink
-          to="https://docs.imageport.app/docs/migrate-from-v1"
+          to="https://imageport.app/zh/docs/migrate-from-v1"
           target="_blank"
           class="font-semibold underline hover:opacity-80"
         >{{ $t("migrationBanner.guideLink") }}</ULink>

--- a/app/components/MigrationBanner.vue
+++ b/app/components/MigrationBanner.vue
@@ -7,13 +7,13 @@
       <p class="text-sm text-primary-800 dark:text-primary-200 flex-1 text-center">
         {{ $t("migrationBanner.message") }}
         <ULink
-          href="https://imageport.app"
+          to="https://imageport.app"
           target="_blank"
           class="font-semibold underline hover:opacity-80"
         >imageport.app</ULink>
         {{ $t("migrationBanner.guide") }}
         <ULink
-          href="https://docs.imageport.app/docs/migrate-from-v1"
+          to="https://docs.imageport.app/docs/migrate-from-v1"
           target="_blank"
           class="font-semibold underline hover:opacity-80"
         >{{ $t("migrationBanner.guideLink") }}</ULink>

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -1,4 +1,10 @@
 {
+  "migrationBanner": {
+    "message": "S3 Image Port v2 is now available at",
+    "guide": "— check out the",
+    "guideLink": "migration guide",
+    "dismiss": "Dismiss banner"
+  },
   "a11y": {
     "nav": {
       "logo": "Logo of S3 Image Port",

--- a/i18n/locales/zh.json
+++ b/i18n/locales/zh.json
@@ -1,4 +1,10 @@
 {
+  "migrationBanner": {
+    "message": "S3 Image Port v2 已上线，访问",
+    "guide": "使用，点击查看",
+    "guideLink": "迁移指南",
+    "dismiss": "关闭横幅"
+  },
   "a11y": {
     "nav": {
       "logo": "S3 图片管家的 Logo",


### PR DESCRIPTION
## Summary
This PR adds a dismissible migration banner to inform users about the availability of S3 Image Port v2 and direct them to the migration guide.

## Key Changes
- **New Component**: Created `MigrationBanner.vue` component that displays a prominent banner with migration information
  - Banner includes links to imageport.app and the migration guide documentation
  - Implements dismiss functionality with localStorage persistence to prevent re-showing the banner
  - Supports dark mode with appropriate color variants
  - Fully accessible with proper ARIA labels

- **Internationalization**: Added translation strings for English and Chinese
  - `migrationBanner.message`: Main announcement text
  - `migrationBanner.guide`: Transitional text between links
  - `migrationBanner.guideLink`: Migration guide link text
  - `migrationBanner.dismiss`: Dismiss button aria-label

- **Integration**: Integrated the banner into the main app layout (`app.vue`)
  - Positioned at the top of the page, below the client-only wrapper and before the navigation menu

## Implementation Details
- The banner uses localStorage to track dismissal state (`migration-banner-dismissed`), ensuring users who dismiss it won't see it again
- Responsive design with flexbox layout that centers content on smaller screens
- Uses Nuxt UI components (`UContainer`, `ULink`, `UButton`) for consistency with the existing design system
- Banner visibility is checked on mount to respect user's previous dismissal preference

https://claude.ai/code/session_01EGX8HyxRz4V3MhzJUY8Fx7