### PR TITLE
Add gallery bulk actions and page size control

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -256,6 +256,9 @@
       "deleteSuccess": "Deleted photos",
       "deleteFailed": "Failed to delete photos"
     },
+    "pagination": {
+      "itemsPerPage": "Per page"
+    },
     "store": {
       "s3SettingsNotFound": "S3 settings not found",
       "failedToFetchPhotos": "Failed to fetch photos",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -254,7 +254,19 @@
       "s3SettingsNotFound": "S3 settings not found",
       "requestingDelete": "Requested delete...",
       "deleteSuccess": "Deleted photos",
-      "deleteFailed": "Failed to delete photos"
+      "deleteFailed": "Failed to delete photos",
+      "refresh": "Refresh",
+      "selectCurrentPage": "Select current page. Shortcut: Ctrl+A",
+      "clearSelection": "Clear selection",
+      "copySelectedUrls": "Copy selected URLs",
+      "deleteSelected": "Delete selected",
+      "selectedUrls": "selected URLs",
+      "deleteConfirm": {
+        "title": "Delete confirm",
+        "description": "Are you sure you want to delete these items?",
+        "cancel": "Cancel",
+        "delete": "Delete"
+      }
     },
     "pagination": {
       "itemsPerPage": "Per page"
@@ -281,7 +293,10 @@
       "searchPrefix": "Search prefix...",
       "noPrefixFound": "No prefix found.",
       "search": "Search",
-      "searchPlaceholder": "Search by image name..."
+      "searchPlaceholder": "Search by image name...",
+      "close": "Close",
+      "clearPrefix": "Clear prefix",
+      "clearPrefixSearch": "Clear prefix search"
     },
     "sort": {
       "sortOptions": "Sort Options",
@@ -294,7 +309,8 @@
       "name": "Name (Path)",
       "sortOrder": "Sort Order",
       "sortOrderDesc": "Show results in ascending or descending order.",
-      "sortOrderToggle": "Sort order toggle"
+      "sortOrderToggle": "Sort order toggle",
+      "close": "Close"
     },
     "date": {
       "all": "All",
@@ -309,6 +325,9 @@
       "options": {
         "open": "Open",
         "info": "Info",
+        "more": "More actions",
+        "backToGallery": "Back to gallery",
+        "copyUrl": "Copy URL",
         "download": "Download",
         "rename": "Rename",
         "delete": "Delete",

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -254,10 +254,19 @@
       "s3SettingsNotFound": "未找到 S3 设置",
       "requestingDelete": "正在请求删除...",
       "deleteSuccess": "已删除照片",
-      "deleteFailed": "删除照片失败"
-    },
-    "pagination": {
-      "itemsPerPage": "每页"
+      "deleteFailed": "删除照片失败",
+      "refresh": "刷新",
+      "selectCurrentPage": "全选当前页。快捷键：Ctrl+A",
+      "clearSelection": "取消选择",
+      "copySelectedUrls": "复制所选 URL",
+      "deleteSelected": "删除所选",
+      "selectedUrls": "所选 URL",
+      "deleteConfirm": {
+        "title": "删除确认",
+        "description": "确定要删除这些项目吗？",
+        "cancel": "取消",
+        "delete": "删除"
+      }
     },
     "store": {
       "s3SettingsNotFound": "未找到 S3 设置",
@@ -281,7 +290,10 @@
       "searchPrefix": "搜索前缀...",
       "noPrefixFound": "未找到前缀。",
       "search": "搜索",
-      "searchPlaceholder": "按图片名称搜索..."
+      "searchPlaceholder": "按图片名称搜索...",
+      "close": "关闭",
+      "clearPrefix": "清除前缀",
+      "clearPrefixSearch": "清除前缀搜索"
     },
     "sort": {
       "sortOptions": "排序选项",
@@ -294,7 +306,8 @@
       "name": "名称 (路径)",
       "sortOrder": "升降序",
       "sortOrderDesc": "以升序或降序显示结果。",
-      "sortOrderToggle": "排序顺序切换"
+      "sortOrderToggle": "排序顺序切换",
+      "close": "关闭"
     },
     "date": {
       "all": "所有",
@@ -341,8 +354,14 @@
           "failed": "下载照片失败",
           "noBody": "下载照片失败"
         },
-        "copyMarkdown": "复制 M↓"
+        "copyMarkdown": "复制 M↓",
+        "more": "更多操作",
+        "backToGallery": "返回图库",
+        "copyUrl": "复制 URL"
       }
+    },
+    "pagination": {
+      "itemsPerPage": "每页"
     }
   },
   "theme": {

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -256,6 +256,9 @@
       "deleteSuccess": "已删除照片",
       "deleteFailed": "删除照片失败"
     },
+    "pagination": {
+      "itemsPerPage": "每页"
+    },
     "store": {
       "s3SettingsNotFound": "未找到 S3 设置",
       "failedToFetchPhotos": "获取照片失败",

--- a/apps/web/src/components/misc/delete-second-confirm.tsx
+++ b/apps/web/src/components/misc/delete-second-confirm.tsx
@@ -7,28 +7,42 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "@/components/ui/dialog";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { Button } from "../ui/button";
-import { ComponentPropsWithRef, useState } from "react";
+import { useState, type ComponentPropsWithRef, type ReactNode } from "react";
+import { useTranslations } from "use-intl";
 
 export function DeleteSecondConfirm({
   deleteFn,
   triggerRender,
+  triggerTooltip,
   itemNames,
 }: {
   deleteFn: () => void;
   itemNames: string[];
   triggerRender: ComponentPropsWithRef<typeof DialogTrigger>["render"];
+  triggerTooltip?: ReactNode;
 }) {
   const [open, setOpen] = useState(false);
+  const t = useTranslations("gallery.control.deleteConfirm");
   return (
     <Dialog open={open} onOpenChange={setOpen}>
-      <DialogTrigger render={triggerRender} />
+      {triggerTooltip ? (
+        <Tooltip>
+          <TooltipTrigger render={<DialogTrigger render={triggerRender} />} />
+          <TooltipContent>{triggerTooltip}</TooltipContent>
+        </Tooltip>
+      ) : (
+        <DialogTrigger render={triggerRender} />
+      )}
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>Delete Confirm</DialogTitle>
-          <DialogDescription>
-            Are you sure you want to delete these items?
-          </DialogDescription>
+          <DialogTitle>{t("title")}</DialogTitle>
+          <DialogDescription>{t("description")}</DialogDescription>
         </DialogHeader>
         <ul className="list-disc list-inside max-h-[300px] overflow-y-auto">
           {itemNames.map((name) => (
@@ -37,7 +51,7 @@ export function DeleteSecondConfirm({
         </ul>
         <DialogFooter>
           <Button variant="outline" onClick={() => setOpen(false)}>
-            Cancel
+            {t("cancel")}
           </Button>
           <Button
             onClick={() => {
@@ -45,7 +59,7 @@ export function DeleteSecondConfirm({
               setOpen(false);
             }}
           >
-            Delete
+            {t("delete")}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/apps/web/src/components/ui/paginationLogic.tsx
+++ b/apps/web/src/components/ui/paginationLogic.tsx
@@ -11,12 +11,24 @@ import {
 // import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { cn } from "@/lib/utils";
 import { Button, buttonVariants } from "./button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "./select";
 
 export interface PaginationWithLinksProps {
   // pageSizeSelectOptions?: {
   //   pageSizeSearchParam?: string;
   //   pageSizeOptions: number[];
   // };
+  pageSizeSelectOptions?: {
+    pageSizeOptions: readonly number[];
+    label: string;
+    onPageSizeChange: (pageSize: number) => void;
+  };
   totalCount: number;
   pageSize: number;
   page: number;
@@ -38,6 +50,7 @@ export interface PaginationWithLinksProps {
  */
 export function PaginationWithLogic({
   // pageSizeSelectOptions,
+  pageSizeSelectOptions,
   pageSize,
   totalCount,
   page,
@@ -155,6 +168,16 @@ export function PaginationWithLogic({
           />
         </div>
       )} */}
+      {pageSizeSelectOptions && (
+        <div className="flex items-center gap-2 md:flex-1">
+          <SelectRowsPerPage
+            options={pageSizeSelectOptions.pageSizeOptions}
+            label={pageSizeSelectOptions.label}
+            setPageSize={pageSizeSelectOptions.onPageSizeChange}
+            pageSize={pageSize}
+          />
+        </div>
+      )}
       <Pagination>
         <PaginationContent className="max-sm:gap-0">
           <PaginationItem>
@@ -242,3 +265,39 @@ function PaginationLink({
 //     </div>
 //   );
 // }
+
+function SelectRowsPerPage({
+  options,
+  label,
+  setPageSize,
+  pageSize,
+}: {
+  options: readonly number[];
+  label: string;
+  setPageSize: (newSize: number) => void;
+  pageSize: number;
+}) {
+  return (
+    <div className="flex items-center gap-2">
+      <span className="whitespace-nowrap text-sm text-muted-foreground">
+        {label}
+      </span>
+      <Select
+        value={String(pageSize)}
+        onValueChange={(value) => setPageSize(Number(value))}
+        itemToStringLabel={(item) => String(item ?? pageSize)}
+      >
+        <SelectTrigger size="sm">
+          <SelectValue>{String(pageSize)}</SelectValue>
+        </SelectTrigger>
+        <SelectContent>
+          {options.map((option) => (
+            <SelectItem key={option} value={String(option)}>
+              {option}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  );
+}

--- a/apps/web/src/modules/gallery/GalleryContent/PhotoGrid.tsx
+++ b/apps/web/src/modules/gallery/GalleryContent/PhotoGrid.tsx
@@ -3,11 +3,11 @@
 import { Button } from "@/components/ui/button";
 import { PaginationWithLogic } from "@/components/ui/paginationLogic";
 import { useAtom, useAtomValue, useSetAtom } from "jotai";
+import { startTransition } from "react";
 import { useEffect, useMemo, useRef } from "react";
 import McEmptyBox from "~icons/mingcute/empty-box-line.jsx";
 import {
   filteredPhotosCountAtom,
-  PER_PAGE,
   useFetchPhotoList,
   showingPhotosAtom,
 } from "../hooks/use-photo-list";
@@ -18,9 +18,16 @@ import {
 import { PhotoItem } from "./PhotoItem/PhotoItem";
 import { useTranslations } from "use-intl";
 import { Loader2 } from "lucide-react";
-import { selectedPhotosAtom, currentPageAtom } from "@/stores/atoms/gallery";
+import {
+  DEFAULT_PAGE_SIZE,
+  PAGE_SIZE_OPTIONS,
+  selectedPhotosAtom,
+  currentPageAtom,
+  pageSizeAtom,
+  type GalleryPageSize,
+} from "@/stores/atoms/gallery";
 import { s3SettingsAtom } from "@/stores/atoms/settings";
-import { Link } from "@tanstack/react-router";
+import { Link, getRouteApi } from "@tanstack/react-router";
 
 export function PhotoGrid() {
   const photos = useAtomValue(showingPhotosAtom);
@@ -145,15 +152,41 @@ function PhotoGridEmpty() {
   );
 }
 
+const route = getRouteApi("/$locale/_root-layout/gallery");
+
 function GalleryPagination() {
   const [page, setPage] = useAtom(currentPageAtom);
+  const [pageSize, setPageSize] = useAtom(pageSizeAtom);
   const filteredPhotoCount = useAtomValue(filteredPhotosCountAtom);
+  const navigate = route.useNavigate();
+  const t = useTranslations("gallery.pagination");
+
+  const handlePageSizeChange = (newPageSize: number) => {
+    const pageSizeValue = newPageSize as GalleryPageSize;
+    setPageSize(pageSizeValue);
+    setPage(1);
+    startTransition(() => {
+      navigate({
+        to: ".",
+        search: (prev) => ({
+          ...prev,
+          pageSize:
+            pageSizeValue === DEFAULT_PAGE_SIZE ? undefined : pageSizeValue,
+        }),
+      });
+    });
+  };
 
   return (
     <PaginationWithLogic
       page={page}
       totalCount={filteredPhotoCount}
-      pageSize={PER_PAGE}
+      pageSize={pageSize}
+      pageSizeSelectOptions={{
+        pageSizeOptions: PAGE_SIZE_OPTIONS,
+        label: t("itemsPerPage"),
+        onPageSizeChange: handlePageSizeChange,
+      }}
       onPageChange={(p) => {
         setPage(p);
       }}

--- a/apps/web/src/modules/gallery/GalleryContent/PhotoItem/photo-item-overlay.tsx
+++ b/apps/web/src/modules/gallery/GalleryContent/PhotoItem/photo-item-overlay.tsx
@@ -1,10 +1,16 @@
 import { Button } from "@/components/ui/button";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 import type { Photo } from "@/stores/schemas/photo";
 import { getRouteApi } from "@tanstack/react-router";
 import { motion } from "motion/react";
 import { useCallback, useMemo, useState } from "react";
 import { useLocale } from "use-intl";
+import { useTranslations } from "use-intl";
 import McCheckFill from "~icons/mingcute/checkbox-fill";
 import McCopy from "~icons/mingcute/copy-2-line.jsx";
 import { PhotoOptions } from "./photo-options";
@@ -79,19 +85,27 @@ function PhotoActionCopyLink({
   photo: Photo;
 }) {
   const operations = usePhotoOperations(photo);
+  const t = useTranslations("gallery.item.options");
   return (
-    <Button
-      aria-label="Copy link"
-      variant="secondary"
-      size="icon-sm"
-      className={className}
-      onClick={(e) => {
-        e.stopPropagation();
-        operations.copyUrl();
-      }}
-    >
-      <McCopy />
-    </Button>
+    <Tooltip>
+      <TooltipTrigger
+        render={
+          <Button
+            aria-label={t("copyUrl")}
+            variant="secondary"
+            size="icon-sm"
+            className={className}
+            onClick={(e) => {
+              e.stopPropagation();
+              operations.copyUrl();
+            }}
+          >
+            <McCopy />
+          </Button>
+        }
+      />
+      <TooltipContent>{t("copyUrl")}</TooltipContent>
+    </Tooltip>
   );
 }
 

--- a/apps/web/src/modules/gallery/GalleryContent/PhotoItem/photo-options.tsx
+++ b/apps/web/src/modules/gallery/GalleryContent/PhotoItem/photo-options.tsx
@@ -18,6 +18,11 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Input } from "@/components/ui/input";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import type { Photo } from "@/stores/schemas/photo";
 import { format } from "date-fns";
 import {
@@ -43,11 +48,13 @@ export function PhotoOptions({
   onOpen,
   onAfterDelete,
   onAfterRename,
+  triggerTooltip,
 }: {
   photo: Photo;
   opened: boolean;
   setOpened: (opened: boolean) => void;
   triggerRender?: ComponentPropsWithRef<typeof DropdownMenuTrigger>["render"];
+  triggerTooltip?: string;
   onOpen?: () => void;
   onAfterDelete?: () => void;
   onAfterRename?: (newKey: string) => void;
@@ -80,15 +87,26 @@ export function PhotoOptions({
   return (
     <>
       <DropdownMenu open={opened} onOpenChange={setOpened} modal={false}>
-        <DropdownMenuTrigger
-          render={
-            triggerRender ?? (
-              <Button variant={"secondary"} size="icon-sm">
-                <MoreHorizontalIcon />
-              </Button>
-            )
-          }
-        />
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <DropdownMenuTrigger
+                render={
+                  triggerRender ?? (
+                    <Button
+                      aria-label={triggerTooltip ?? t("more")}
+                      variant={"secondary"}
+                      size="icon-sm"
+                    >
+                      <MoreHorizontalIcon />
+                    </Button>
+                  )
+                }
+              />
+            }
+          />
+          <TooltipContent>{triggerTooltip ?? t("more")}</TooltipContent>
+        </Tooltip>
         <DropdownMenuContent>
           {onOpen && (
             <DropdownMenuItem onClick={onOpen}>

--- a/apps/web/src/modules/gallery/GalleryControl/DisplayControl.tsx
+++ b/apps/web/src/modules/gallery/GalleryControl/DisplayControl.tsx
@@ -6,7 +6,12 @@ import {
   galleryFilterOptionsToSearchParams,
   galleryFilterOptionsFromSearchParams,
 } from "../hooks/use-display-control";
-import { currentPageAtom, displayOptionsAtom } from "@/stores/atoms/gallery";
+import {
+  DEFAULT_PAGE_SIZE,
+  currentPageAtom,
+  displayOptionsAtom,
+  pageSizeAtom,
+} from "@/stores/atoms/gallery";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { buttonVariants } from "@/components/ui/button";
@@ -15,6 +20,11 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { FilterIcon, ArrowUpDownIcon } from "lucide-react";
 import { FilterPopoverContent } from "./FilterPopoverContent";
 import { SortPopoverContent } from "./SortPopoverContent";
@@ -30,33 +40,36 @@ function useSyncDisplayAtomToSearchParams() {
   const setCurrentPage = useSetAtom(currentPageAtom);
 
   const displayOptions = useAtomValue(displayOptionsAtom);
+  const pageSize = useAtomValue(pageSizeAtom);
   const lastDisplayOptionsRef = useRef<typeof displayOptions>(displayOptions);
   useEffect(() => {
     const lastDisplayOptions = lastDisplayOptionsRef.current;
     if (!equal(lastDisplayOptions, displayOptions)) {
-      const search = galleryFilterOptionsToSearchParams(displayOptions);
+      const search = galleryFilterOptionsToSearchParams(displayOptions, pageSize);
       startTransition(() => {
         setCurrentPage(1);
         navigate({ to: ".", search: search });
       });
     }
     lastDisplayOptionsRef.current = displayOptions;
-  }, [displayOptions, navigate, setCurrentPage]);
+  }, [displayOptions, navigate, pageSize, setCurrentPage]);
 }
 
 function useSyncSearchParamsToDisplayAtom() {
   const searchParams = route.useSearch();
   const setDisplayOptions = useSetAtom(displayOptionsAtom);
   const setCurrentPage = useSetAtom(currentPageAtom);
+  const setPageSize = useSetAtom(pageSizeAtom);
   const lastSearchParamsRef = useRef<typeof searchParams | null>(null);
   useEffect(() => {
     const lastSearchParams = lastSearchParamsRef.current;
     if (!equal(lastSearchParams, searchParams)) {
       setCurrentPage(1);
       setDisplayOptions(galleryFilterOptionsFromSearchParams(searchParams));
+      setPageSize(searchParams.pageSize ?? DEFAULT_PAGE_SIZE);
     }
     lastSearchParamsRef.current = searchParams;
-  }, [searchParams, setDisplayOptions, setCurrentPage]);
+  }, [searchParams, setDisplayOptions, setCurrentPage, setPageSize]);
 }
 
 function useSyncDisplayAtomAndSearch() {
@@ -67,7 +80,8 @@ function useSyncDisplayAtomAndSearch() {
 export function DisplayControl() {
   const [search, handleUpdate] = useAtom(displayOptionsAtom);
   useSyncDisplayAtomAndSearch();
-  const t = useTranslations("gallery.filter");
+  const tFilter = useTranslations("gallery.filter");
+  const tSort = useTranslations("gallery.sort");
 
   const [filterPopoverOpen, setFilterPopoverOpen] = useState(false);
   const [sortPopoverOpen, setSortPopoverOpen] = useState(false);
@@ -85,7 +99,7 @@ export function DisplayControl() {
   return (
     <div className="flex items-center gap-2">
       <Input
-        placeholder={t("searchPlaceholder")}
+        placeholder={tFilter("searchPlaceholder")}
         className="grow max-w-72"
         onChange={(e) => {
           handleUpdate((prev) => ({ ...prev, searchTerm: e.target.value }));
@@ -93,17 +107,24 @@ export function DisplayControl() {
         value={search.searchTerm}
       />
       <Popover open={filterPopoverOpen} onOpenChange={setFilterPopoverOpen}>
-        <PopoverTrigger>
-          <NotificationBadge
-            label={filterActiveCount}
-            show={filterActiveCount > 0}
-            variant={"destructiveBackground"}
-          >
-            <div className={buttonVariants({ size: "icon" })}>
-              <FilterIcon className="h-4 w-4" />
-            </div>
-          </NotificationBadge>
-        </PopoverTrigger>
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <PopoverTrigger>
+              <NotificationBadge
+                label={filterActiveCount}
+                show={filterActiveCount > 0}
+                variant={"destructiveBackground"}
+              >
+                <div className={buttonVariants({ size: "icon" })}>
+                  <FilterIcon className="h-4 w-4" />
+                </div>
+              </NotificationBadge>
+              </PopoverTrigger>
+            }
+          />
+          <TooltipContent>{tFilter("filterOptions")}</TooltipContent>
+        </Tooltip>
         <PopoverContent className="w-100">
           <FilterPopoverContent
             currentDisplayOptions={search}
@@ -116,13 +137,24 @@ export function DisplayControl() {
       </Popover>
 
       <Popover open={sortPopoverOpen} onOpenChange={setSortPopoverOpen}>
-        <PopoverTrigger
-          render={
-            <Button variant="outline" size="icon">
-              <ArrowUpDownIcon className="h-4 w-4" />
-            </Button>
-          }
-        />
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <PopoverTrigger
+                render={
+                  <Button
+                    aria-label={tSort("sortOptions")}
+                    variant="outline"
+                    size="icon"
+                  >
+                    <ArrowUpDownIcon className="h-4 w-4" />
+                  </Button>
+                }
+              />
+            }
+          />
+          <TooltipContent>{tSort("sortOptions")}</TooltipContent>
+        </Tooltip>
         <PopoverContent className="w-80">
           <SortPopoverContent
             currentDisplayOptions={search}

--- a/apps/web/src/modules/gallery/GalleryControl/FilterPopoverContent.tsx
+++ b/apps/web/src/modules/gallery/GalleryControl/FilterPopoverContent.tsx
@@ -14,6 +14,11 @@ import {
   InputGroupButton,
   InputGroupInput,
 } from "@/components/ui/input-group";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { useMemo } from "react";
 
 interface FilterPopoverContentProps {
@@ -34,13 +39,21 @@ export function FilterPopoverContent({
       <div className="space-y-2">
         <div className="flex items-center justify-between">
           <h4 className="font-medium leading-none">{t("filterOptions")}</h4>
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={() => setFilterPopoverOpen(false)}
-          >
-            <XIcon className="h-4 w-4" />
-          </Button>
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <Button
+                  aria-label={t("close")}
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => setFilterPopoverOpen(false)}
+                >
+                  <XIcon className="h-4 w-4" />
+                </Button>
+              }
+            />
+            <TooltipContent>{t("close")}</TooltipContent>
+          </Tooltip>
         </div>
         <p className="text-sm text-muted-foreground">{t("filterByProperty")}</p>
       </div>
@@ -151,12 +164,21 @@ function PrefixSelector({
                 <Combobox.Input render={<InputGroupInput />} />
 
                 <InputGroupAddon align="inline-end">
-                  <Combobox.Clear
-                    data-slot="combobox-clear"
-                    render={<InputGroupButton variant="ghost" size="icon-xs" />}
-                  >
-                    <XIcon className="pointer-events-none" />
-                  </Combobox.Clear>
+                  <Tooltip>
+                    <TooltipTrigger
+                      render={
+                        <Combobox.Clear
+                          data-slot="combobox-clear"
+                          render={
+                            <InputGroupButton variant="ghost" size="icon-xs" />
+                          }
+                        >
+                          <XIcon className="pointer-events-none" />
+                        </Combobox.Clear>
+                      }
+                    />
+                    <TooltipContent>{t("clearPrefixSearch")}</TooltipContent>
+                  </Tooltip>
                 </InputGroupAddon>
               </InputGroup>
               <Combobox.Empty className="text-muted-foreground hidden w-full justify-center py-2 text-center text-sm group-data-empty/combobox-content:flex">
@@ -189,14 +211,22 @@ function PrefixSelector({
           </Combobox.Positioner>
         </Combobox.Portal>
       </Combobox.Root>
-      <Button
-        variant="outline"
-        size="icon"
-        disabled={currentPrefix === null}
-        onClick={() => handleUpdate({ prefix: undefined })}
-      >
-        <XIcon className="size-5" />
-      </Button>
+      <Tooltip>
+        <TooltipTrigger
+          render={
+            <Button
+              aria-label={t("clearPrefix")}
+              variant="outline"
+              size="icon"
+              disabled={currentPrefix === null}
+              onClick={() => handleUpdate({ prefix: undefined })}
+            >
+              <XIcon className="size-5" />
+            </Button>
+          }
+        />
+        <TooltipContent>{t("clearPrefix")}</TooltipContent>
+      </Tooltip>
     </div>
   );
 }

--- a/apps/web/src/modules/gallery/GalleryControl/GalleryControl.tsx
+++ b/apps/web/src/modules/gallery/GalleryControl/GalleryControl.tsx
@@ -1,4 +1,9 @@
 import { Button } from "@/components/ui/button";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { useAtom, useAtomValue } from "jotai";
 import {
   filteredPhotosAtom,
@@ -17,6 +22,7 @@ import { cn } from "@/lib/utils";
 import { useDeletePhotos } from "../hooks/use-delete";
 import { selectedPhotosAtom } from "@/stores/atoms/gallery";
 import { CopyIcon } from "lucide-react";
+import { useTranslations } from "use-intl";
 import { useCopy } from "@/lib/hooks/use-copy";
 
 export function GalleryControl() {
@@ -26,6 +32,7 @@ export function GalleryControl() {
   const s3Settings = useAtomValue(validS3SettingsAtom);
   const handleDelete = useDeletePhotos();
   const { fetchPhotoList, isLoading } = useFetchPhotoList();
+  const t = useTranslations("gallery.control");
   const { copy } = useCopy();
 
   const selectCurrentPage = () => {
@@ -42,48 +49,84 @@ export function GalleryControl() {
     const urls = filteredPhotos
       .filter((photo) => selectedPhotos.has(photo.Key))
       .map((photo) => photo.url);
-    copy(urls.join("\n"));
+    copy(urls.join("\n"), t("selectedUrls"));
   };
 
   return (
     <div className="flex gap-2 justify-between">
       {s3Settings === undefined && <InvalidS3Dialog />}
       <div className="flex gap-2">
-        <Button
-          onClick={() => fetchPhotoList()}
-          disabled={isLoading}
-          size={"icon"}
-        >
-          <McRefresh className={cn(isLoading && "animate-spin")} />
-        </Button>
-        <Button
-          onClick={selectCurrentPage}
-          disabled={showingPhotos.length === 0}
-          size={"icon"}
-        >
-          <McCheckbox />
-        </Button>
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <Button
+                aria-label={t("refresh")}
+                onClick={() => fetchPhotoList()}
+                disabled={isLoading}
+                size={"icon"}
+              >
+                <McRefresh className={cn(isLoading && "animate-spin")} />
+              </Button>
+            }
+          />
+          <TooltipContent>{t("refresh")}</TooltipContent>
+        </Tooltip>
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <Button
+                aria-label={t("selectCurrentPage")}
+                onClick={selectCurrentPage}
+                disabled={showingPhotos.length === 0}
+                size={"icon"}
+              >
+                <McCheckbox />
+              </Button>
+            }
+          />
+          <TooltipContent>{t("selectCurrentPage")}</TooltipContent>
+        </Tooltip>
         {selectedPhotos.size > 0 && (
           <>
-            <Button
-              variant="secondary"
-              onClick={() => {
-                setSelectedPhotos(new Set<string>());
-              }}
-            >
-              <McCheckbox /> {selectedPhotos.size}
-            </Button>
-            <Button
-              variant="secondary"
-              onClick={copySelectedUrls}
-            >
-              <CopyIcon /> {selectedPhotos.size}
-            </Button>
+            <Tooltip>
+              <TooltipTrigger
+                render={
+                  <Button
+                    aria-label={t("clearSelection")}
+                    variant="secondary"
+                    onClick={() => {
+                      setSelectedPhotos(new Set<string>());
+                    }}
+                  >
+                    <McCheckbox /> {selectedPhotos.size}
+                  </Button>
+                }
+              />
+              <TooltipContent>{t("clearSelection")}</TooltipContent>
+            </Tooltip>
+            <Tooltip>
+              <TooltipTrigger
+                render={
+                  <Button
+                    aria-label={t("copySelectedUrls")}
+                    variant="secondary"
+                    onClick={copySelectedUrls}
+                  >
+                    <CopyIcon /> {selectedPhotos.size}
+                  </Button>
+                }
+              />
+              <TooltipContent>{t("copySelectedUrls")}</TooltipContent>
+            </Tooltip>
             <DeleteSecondConfirm
               deleteFn={() => handleDelete(Array.from(selectedPhotos))}
               itemNames={Array.from(selectedPhotos)}
+              triggerTooltip={t("deleteSelected")}
               triggerRender={
-                <Button variant={"destructive"}>
+                <Button
+                  aria-label={t("deleteSelected")}
+                  variant={"destructive"}
+                >
                   <McDelete /> {selectedPhotos.size}
                 </Button>
               }

--- a/apps/web/src/modules/gallery/GalleryControl/GalleryControl.tsx
+++ b/apps/web/src/modules/gallery/GalleryControl/GalleryControl.tsx
@@ -1,6 +1,7 @@
 import { Button } from "@/components/ui/button";
 import { useAtom, useAtomValue } from "jotai";
 import {
+  filteredPhotosAtom,
   showingPhotosAtom,
   useFetchPhotoList,
 } from "../hooks/use-photo-list";
@@ -15,13 +16,17 @@ import { DeleteSecondConfirm } from "@/components/misc/delete-second-confirm";
 import { cn } from "@/lib/utils";
 import { useDeletePhotos } from "../hooks/use-delete";
 import { selectedPhotosAtom } from "@/stores/atoms/gallery";
+import { CopyIcon } from "lucide-react";
+import { useCopy } from "@/lib/hooks/use-copy";
 
 export function GalleryControl() {
   const [selectedPhotos, setSelectedPhotos] = useAtom(selectedPhotosAtom);
   const showingPhotos = useAtomValue(showingPhotosAtom);
+  const filteredPhotos = useAtomValue(filteredPhotosAtom);
   const s3Settings = useAtomValue(validS3SettingsAtom);
   const handleDelete = useDeletePhotos();
   const { fetchPhotoList, isLoading } = useFetchPhotoList();
+  const { copy } = useCopy();
 
   const selectCurrentPage = () => {
     setSelectedPhotos((prev) => {
@@ -31,6 +36,13 @@ export function GalleryControl() {
       }
       return newSet;
     });
+  };
+
+  const copySelectedUrls = () => {
+    const urls = filteredPhotos
+      .filter((photo) => selectedPhotos.has(photo.Key))
+      .map((photo) => photo.url);
+    copy(urls.join("\n"));
   };
 
   return (
@@ -60,6 +72,12 @@ export function GalleryControl() {
               }}
             >
               <McCheckbox /> {selectedPhotos.size}
+            </Button>
+            <Button
+              variant="secondary"
+              onClick={copySelectedUrls}
+            >
+              <CopyIcon /> {selectedPhotos.size}
             </Button>
             <DeleteSecondConfirm
               deleteFn={() => handleDelete(Array.from(selectedPhotos))}

--- a/apps/web/src/modules/gallery/GalleryControl/GalleryControl.tsx
+++ b/apps/web/src/modules/gallery/GalleryControl/GalleryControl.tsx
@@ -1,6 +1,9 @@
 import { Button } from "@/components/ui/button";
 import { useAtom, useAtomValue } from "jotai";
-import { useFetchPhotoList } from "../hooks/use-photo-list";
+import {
+  showingPhotosAtom,
+  useFetchPhotoList,
+} from "../hooks/use-photo-list";
 import { validS3SettingsAtom } from "@/stores/atoms/settings";
 import McCheckbox from "~icons/mingcute/checkbox-line.jsx";
 import McDelete from "~icons/mingcute/delete-3-line.jsx";
@@ -15,9 +18,20 @@ import { selectedPhotosAtom } from "@/stores/atoms/gallery";
 
 export function GalleryControl() {
   const [selectedPhotos, setSelectedPhotos] = useAtom(selectedPhotosAtom);
+  const showingPhotos = useAtomValue(showingPhotosAtom);
   const s3Settings = useAtomValue(validS3SettingsAtom);
   const handleDelete = useDeletePhotos();
   const { fetchPhotoList, isLoading } = useFetchPhotoList();
+
+  const selectCurrentPage = () => {
+    setSelectedPhotos((prev) => {
+      const newSet = new Set(prev);
+      for (const photo of showingPhotos) {
+        newSet.add(photo.Key);
+      }
+      return newSet;
+    });
+  };
 
   return (
     <div className="flex gap-2 justify-between">
@@ -29,6 +43,13 @@ export function GalleryControl() {
           size={"icon"}
         >
           <McRefresh className={cn(isLoading && "animate-spin")} />
+        </Button>
+        <Button
+          onClick={selectCurrentPage}
+          disabled={showingPhotos.length === 0}
+          size={"icon"}
+        >
+          <McCheckbox />
         </Button>
         {selectedPhotos.size > 0 && (
           <>

--- a/apps/web/src/modules/gallery/GalleryControl/SortPopoverContent.tsx
+++ b/apps/web/src/modules/gallery/GalleryControl/SortPopoverContent.tsx
@@ -11,6 +11,11 @@ import { Switch } from "@/components/animate-ui/components/base/switch";
 import { XIcon } from "lucide-react";
 import { GalleryFilterOptions as DisplayOptions } from "@/stores/schemas/gallery/filter";
 import { useTranslations } from "use-intl";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 interface SortPopoverContentProps {
   currentDisplayOptions: DisplayOptions;
@@ -32,13 +37,21 @@ export function SortPopoverContent({
       <div className="space-y-2">
         <div className="flex items-center justify-between">
           <h4 className="font-medium leading-none">{t("sortOptions")}</h4>
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={() => setSortPopoverOpen(false)}
-          >
-            <XIcon className="h-4 w-4" />
-          </Button>
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <Button
+                  aria-label={t("close")}
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => setSortPopoverOpen(false)}
+                >
+                  <XIcon className="h-4 w-4" />
+                </Button>
+              }
+            />
+            <TooltipContent>{t("close")}</TooltipContent>
+          </Tooltip>
         </div>
         <p className="text-sm text-muted-foreground">
           {isSearchActive ? t("sortActiveMessage") : t("sortInactiveMessage")}

--- a/apps/web/src/modules/gallery/hooks/use-display-control.ts
+++ b/apps/web/src/modules/gallery/hooks/use-display-control.ts
@@ -7,6 +7,19 @@ import {
   galleryFilterDefault,
   timeRangesGetter,
 } from "@/stores/schemas/gallery/filter";
+import {
+  DEFAULT_PAGE_SIZE,
+  PAGE_SIZE_OPTIONS,
+  type GalleryPageSize,
+} from "@/stores/atoms/gallery";
+
+const pageSizeSchema = z.coerce
+  .number()
+  .refine((value): value is GalleryPageSize =>
+    PAGE_SIZE_OPTIONS.includes(value as GalleryPageSize),
+  )
+  .optional()
+  .catch(undefined);
 
 export const galleryFilterSearchParamsSchema = z.object({
   searchTerm: z.string().optional().catch(undefined),
@@ -14,10 +27,12 @@ export const galleryFilterSearchParamsSchema = z.object({
   dateRangeType: z.string().optional().catch(undefined),
   sortBy: z.string().optional().catch(undefined),
   sortOrder: z.string().optional().catch(undefined),
+  pageSize: pageSizeSchema,
 });
 
 export function galleryFilterOptionsToSearchParams(
   options: GalleryFilterOptions,
+  pageSize: GalleryPageSize = DEFAULT_PAGE_SIZE,
 ): z.infer<typeof galleryFilterSearchParamsSchema> {
   const params: z.infer<typeof galleryFilterSearchParamsSchema> = {};
   const { searchTerm, prefix, dateRangeType, sortBy, sortOrder } = options;
@@ -42,6 +57,9 @@ export function galleryFilterOptionsToSearchParams(
   }
   if (sortOrder !== galleryFilterDefault.sortOrder) {
     params.sortOrder = sortOrder;
+  }
+  if (pageSize !== DEFAULT_PAGE_SIZE) {
+    params.pageSize = pageSize;
   }
   return params;
 }

--- a/apps/web/src/modules/gallery/hooks/use-photo-list.ts
+++ b/apps/web/src/modules/gallery/hooks/use-photo-list.ts
@@ -10,6 +10,7 @@ import { validS3SettingsAtom } from "@/stores/atoms/settings";
 import { getTimeRange } from "./use-display-control";
 import {
   currentPageAtom,
+  pageSizeAtom,
   photosAtom,
   displayOptionsAtom,
   galleryDirtyStatusAtom,
@@ -91,11 +92,10 @@ export const filteredPhotosCountAtom = atom((get) => {
   return get(filteredPhotosAtom).length;
 });
 
-export const PER_PAGE = 20;
-
 export const showingPhotosAtom = atom<Photo[]>((get) => {
-  const start = (get(currentPageAtom) - 1) * PER_PAGE;
-  const end = start + PER_PAGE;
+  const pageSize = get(pageSizeAtom);
+  const start = (get(currentPageAtom) - 1) * pageSize;
+  const end = start + pageSize;
   return get(filteredPhotosAtom).slice(start, end);
 });
 

--- a/apps/web/src/modules/photo/PhotoModal.tsx
+++ b/apps/web/src/modules/photo/PhotoModal.tsx
@@ -1,11 +1,16 @@
 "use client";
 import { s3Key2Url } from "@/lib/s3/s3-key";
 import { useAtomValue } from "jotai";
-import { useLocale } from "use-intl";
+import { useLocale, useTranslations } from "use-intl";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { validS3SettingsAtom } from "@/stores/atoms/settings";
 import { PhotoImg } from "@/modules/gallery/GalleryContent/PhotoItem/photo-img";
 import { Button } from "@/components/ui/button";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import McArrowLeft from "~icons/mingcute/arrow-left-line";
 import { CircleEllipsisIcon, CopyIcon, Trash2Icon } from "lucide-react";
 import { photosAtomReadOnly } from "../gallery/hooks/use-photo-list";
@@ -84,6 +89,7 @@ function PhotoModalToolbar({ photo }: { photo: Photo }) {
   const navigate = route.useNavigate();
   const search = route.useSearch();
   const locale = useLocale();
+  const t = useTranslations("gallery.item.options");
   const [dropdownOpened, setDropdownOpened] = useState(false);
 
   const operations = usePhotoOperations(photo);
@@ -131,19 +137,44 @@ function PhotoModalToolbar({ photo }: { photo: Photo }) {
   return (
     <div className="flex justify-between items-center text-white p-2 relative z-20">
       <div className="">
-        <Button size="icon" variant="ghost" onClick={handleBack}>
-          <McArrowLeft />
-        </Button>
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <Button
+                aria-label={t("backToGallery")}
+                size="icon"
+                variant="ghost"
+                onClick={handleBack}
+              >
+                <McArrowLeft />
+              </Button>
+            }
+          />
+          <TooltipContent>{t("backToGallery")}</TooltipContent>
+        </Tooltip>
       </div>
       <div className="flex gap-2 items-center">
-        <Button size="icon" variant="ghost" onClick={operations.copyUrl}>
-          <CopyIcon />
-        </Button>
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <Button
+                aria-label={t("copyUrl")}
+                size="icon"
+                variant="ghost"
+                onClick={operations.copyUrl}
+              >
+                <CopyIcon />
+              </Button>
+            }
+          />
+          <TooltipContent>{t("copyUrl")}</TooltipContent>
+        </Tooltip>
         <DeleteSecondConfirm
           deleteFn={handleDelete}
           itemNames={[photo.Key]}
+          triggerTooltip={t("delete")}
           triggerRender={
-            <Button size="icon" variant="ghost">
+            <Button aria-label={t("delete")} size="icon" variant="ghost">
               <Trash2Icon />
             </Button>
           }
@@ -154,8 +185,9 @@ function PhotoModalToolbar({ photo }: { photo: Photo }) {
           setOpened={setDropdownOpened}
           onAfterDelete={handleBack}
           onAfterRename={handleAfterRename}
+          triggerTooltip={t("more")}
           triggerRender={
-            <Button size="icon" variant="ghost">
+            <Button aria-label={t("more")} size="icon" variant="ghost">
               <CircleEllipsisIcon />
             </Button>
           }

--- a/apps/web/src/stores/atoms/gallery.ts
+++ b/apps/web/src/stores/atoms/gallery.ts
@@ -12,6 +12,10 @@ export const selectedPhotosAtom = atom<Set<string>>(new Set<string>());
 export const displayOptionsAtom =
   atom<GalleryFilterOptions>(galleryFilterDefault);
 export const currentPageAtom = atom(1);
+export const PAGE_SIZE_OPTIONS = [20, 50, 100] as const;
+export const DEFAULT_PAGE_SIZE = PAGE_SIZE_OPTIONS[0];
+export type GalleryPageSize = (typeof PAGE_SIZE_OPTIONS)[number];
+export const pageSizeAtom = atom<GalleryPageSize>(DEFAULT_PAGE_SIZE);
 
 export const galleryDirtyStatusAtom = atom(false);
 export const setGalleryDirtyAtom = atom(null, (_, set) => {
@@ -24,6 +28,7 @@ export const resetGalleryStateAtom = atom(null, (_get, set) => {
   set(selectedPhotosAtom, new Set<string>());
   set(displayOptionsAtom, galleryFilterDefault); // Reset display options
   set(currentPageAtom, 1);
+  set(pageSizeAtom, DEFAULT_PAGE_SIZE);
   set(clearNaturalSizeCacheAtom);
   set(galleryDirtyStatusAtom, true); // gallery is always dirty after reset to trigger a refresh
 });


### PR DESCRIPTION
Preview: https://imageport.thok.top/

## Summary

Adds bulk selection, selected URL copying, page size controls, and localized tooltips to the gallery/photo management flow.

- add a visible “select current page” button next to refresh
- add a “copy selected URLs” action for selected gallery items
- add localized tooltips for icon-only gallery/photo controls
- add a page size selector to gallery pagination
- localize the shared delete confirmation dialog used by gallery/photo delete actions

## Details

### Gallery bulk actions

The gallery toolbar now supports selecting all images on the current page from a visible button. This matches the existing Ctrl+A behavior.

The copy URLs action writes the selected image URLs to the clipboard in gallery order, one URL per line.

### Pagination

The gallery pagination now supports choosing how many images to show per page: 20,50,100

The default remains 20. Non-default page sizes are preserved through the `pageSize` URL search parameter, and changing the page size resets the gallery to page 1.


### Tooltips and localization

Icon-only buttons in the gallery/photo management flow now have hover labels. 

Covered areas include:

- gallery refresh/select/clear/copy/delete actions
- filter and sort controls
- clear filter controls
- photo card copy/more actions
- photo modal back/copy/delete/more actions

The delete confirmation dialog used by gallery/photo delete actions now uses i18n instead of hardcoded English text.
