### PR TITLE
Fix gallery search for deeply nested image keys

### DIFF
--- a/apps/web/src/modules/image-catalog/image-catalog.test.ts
+++ b/apps/web/src/modules/image-catalog/image-catalog.test.ts
@@ -209,6 +209,33 @@ describe("deep image catalog", () => {
     unsubscribe();
   });
 
+  it("finds an exact filename fragment behind a long storage prefix", () => {
+    const deeplyNestedImage = {
+      key: "archive/2024/events/long-directory-name/photo_123456.jpg",
+      lastModified: "2024-11-10T00:00:00.000Z",
+    };
+    const catalog = createImageCatalog({
+      cacheStorage: new ControllableStorage({
+        "s3ip:gallery:photos": JSON.stringify([deeplyNestedImage, alpha]),
+      }),
+    });
+    const store = configuredStore();
+    const unsubscribe = store.sub(catalog.state, () => {});
+
+    store.set(catalog.view.filter, {
+      searchTerm: "123456",
+      prefix: undefined,
+      dateRangeType: [null, null],
+      sortBy: "key",
+      sortOrder: "desc",
+    });
+
+    expect(
+      store.get(catalog.state).gallery.filteredImages.map((image) => image.key),
+    ).toEqual([deeplyNestedImage.key]);
+    unsubscribe();
+  });
+
   it.each([
     { name: "cached-empty", images: [] },
     { name: "ready", images: [alpha] },

--- a/apps/web/src/modules/image-catalog/index.ts
+++ b/apps/web/src/modules/image-catalog/index.ts
@@ -294,7 +294,11 @@ export function createImageCatalog({
     const images = get(imagesAtom);
     const filter = get(filterAtom);
     const searched = filter.searchTerm
-      ? new Fuse(images, { keys: ["key"], threshold: 0.3 })
+      ? new Fuse(images, {
+          keys: ["key"],
+          threshold: 0.3,
+          ignoreLocation: true,
+        })
           .search(filter.searchTerm)
           .map(({ item }) => item)
       : images;


### PR DESCRIPTION
## Summary
- make gallery fuzzy search ignore the match position within an S3 object key
- keep the existing 0.3 typo-tolerance threshold
- add a regression test for the filename and search term reported in issue #126

## Verification
- image catalog test suite: 42 passed
- ESLint and diff checks passed
- browser verification with the reported long key plus a nonmatching control object

Closes #126